### PR TITLE
Add support for custom attributes

### DIFF
--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -83,6 +83,9 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
         <password>password</password> <!-- or read from property -->
         <pageTitlePrefix xml:space="preserve">Doc :: </pageTitlePrefix>
         <pageTitleSuffix xml:space="preserve"> [1.0]</pageTitleSuffix>
+        <attributes>
+            <key>value</key>
+        </attributes>
       </configuration>
     </plugin>
   </plugins>
@@ -122,6 +125,10 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
 | password
 | The password of the user to use for publishing.
 | mandatory
+
+| attributes
+| Attributes used during AsciiDoctor processing.
+| optional (default to empty)
 
 | pageTitlePrefix
 | The prefix to be prepended to every page title.

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -21,6 +21,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.asciidoctor.Attributes;
 import org.sahli.asciidoc.confluence.publisher.client.ConfluencePublisher;
 import org.sahli.asciidoc.confluence.publisher.client.ConfluencePublisherListener;
 import org.sahli.asciidoc.confluence.publisher.client.http.ConfluencePage;
@@ -34,6 +35,7 @@ import org.sahli.asciidoc.confluence.publisher.converter.PrefixAndSuffixPageTitl
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.Map;
 
 /**
  * @author Alain Sahli
@@ -67,6 +69,9 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
     private String password;
 
     @Parameter
+    private Map<String, Object> attributes;
+
+    @Parameter
     private String pageTitlePrefix;
 
     @Parameter
@@ -81,7 +86,8 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
             AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(this.asciidocRootFolder.toPath(), Charset.forName(this.sourceEncoding));
 
             AsciidocConfluenceConverter asciidocConfluenceConverter = new AsciidocConfluenceConverter(this.spaceKey, this.ancestorId);
-            ConfluencePublisherMetadata confluencePublisherMetadata = asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, pageTitlePostProcessor, this.confluencePublisherBuildFolder.toPath());
+            Attributes attributes = new Attributes(this.attributes);
+            ConfluencePublisherMetadata confluencePublisherMetadata = asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, pageTitlePostProcessor, this.confluencePublisherBuildFolder.toPath(), attributes);
 
             ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(this.rootConfluenceUrl, this.username, this.password);
             ConfluencePublisherListener confluencePublisherListener = new LoggingConfluencePublisherListener(getLog());


### PR DESCRIPTION
In my use case I have a necessity to add custom attributes dynamically to allow publishing Spring Rest Docs (with generated snippets) to Confluence. I replace the {snippets} attribute with the correct path to the generated snippets and they are properly included. Changes in this pull request allow adding the custom {snippets} attribute.