### PR TITLE
add title or alt text to most converted block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ target/
 !.idea/scopes/
 .idea/scopes/*
 !.idea/scopes/Copyrighted_Sources.xml
+.project
+.settings
+.classpath
+.factorypath

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
@@ -1,5 +1,5 @@
 = html_tag_if (attr? :link), :a, {href: (attr :link)}
-  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(alt if alt?)
+  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(title if title?)
     ri:attachment ri:filename=(attr :target)
   - if title?
     h6 =captioned_title

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
@@ -2,4 +2,5 @@
   ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(title if title?)
     ri:attachment ri:filename=(attr :target)
   - if title?
-    h6 =captioned_title
+    div class="cp-image-title"
+      em =captioned_title

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
@@ -1,3 +1,5 @@
 = html_tag_if (attr? :link), :a, {href: (attr :link)}
-  ac:image ac:height=(attr :height) ac:width=(attr :width)
+  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(alt if alt?)
     ri:attachment ri:filename=(attr :target)
+  - if title?
+    h6 =captioned_title

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_listing.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_listing.html.slim
@@ -2,9 +2,13 @@
   ac:structured-macro ac:name="code"
     - if (confluence_supported_lang "#{source_lang}")
       ac:parameter ac:name="language" #{source_lang}
+    - if title?
+      ac:parameter ac:name="title" #{title}
     ac:plain-text-body
       <![CDATA[#{content}]]>
 - else
   ac:structured-macro ac:name="noformat"
+    - if title?
+      ac:parameter ac:name="title" #{title}
     ac:plain-text-body
       <![CDATA[#{content}]]>

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_olist.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_olist.html.slim
@@ -1,3 +1,5 @@
+- if title?
+  h4 =title
 ol
   - items.each do |item|
     li

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_olist.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_olist.html.slim
@@ -1,5 +1,6 @@
 - if title?
-  h4 =title
+  div class="cp-olist-title"
+    em =title
 ol
   - items.each do |item|
     li

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
@@ -1,3 +1,4 @@
 - if title?
-  h4 =title
-p = content
+  div class="cp-para-title"
+    em =title
+p =content

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
@@ -1,1 +1,3 @@
+- if title?
+  h4 =title
 p = content

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
@@ -1,4 +1,4 @@
 - if title?
-  div class="cp-para-title"
+  div class="cp-paragraph-title"
     em =title
 p =content

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_ulist.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_ulist.html.slim
@@ -1,5 +1,6 @@
 - if title?
-  h4 =title
+  div class="cp-ulist-title"
+    em =title
 ul
   - items.each do |item|
     li

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_ulist.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_ulist.html.slim
@@ -1,3 +1,5 @@
+- if title?
+  h4 =title
 ul
   - items.each do |item|
     li

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
@@ -1,3 +1,3 @@
 = html_tag_if (attr? :link), :a, {href: (attr :link)}
-  ac:image ac:height=(attr :height) ac:width=(attr :width)
+  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:alt=(attr :alt if attr :alt)
     ri:attachment ri:filename=(target)

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -964,7 +964,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <ac:image><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image> with inline image</p>";
+        String expectedContent = "<p>Some text <ac:image ac:alt=\"sunset\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -977,7 +977,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <a href=\"http://www.foo.ch\"><ac:image ac:height=\"20\" ac:width=\"16\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></a> with inline image</p>";
+        String expectedContent = "<p>Some text <a href=\"http://www.foo.ch\"><ac:image ac:height=\"20\" ac:width=\"16\" ac:alt=\"Sunset\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></a> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -990,7 +990,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <ac:image><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image> with inline image</p>";
+        String expectedContent = "<p>Some text <ac:image ac:alt=\"sunset\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -161,6 +161,25 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithListingAndTitle_returnsConfluencePageContentWithMacroWithNameNoFormatAndTitle() {
+        // arrange
+        String adocContent = ".A block title\n" + 
+                "----\n" +
+                "import java.util.List;\n" +
+                "----";
+
+        // act
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ac:structured-macro ac:name=\"noformat\">" +
+                "<ac:parameter ac:name=\"title\">A block title</ac:parameter>" +
+                "<ac:plain-text-body><![CDATA[import java.util.List;]]></ac:plain-text-body>" +
+                "</ac:structured-macro>";
+        assertThat(asciiDocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithSourceListing_returnsConfluencePageContentWithMacroWithNameCode() {
         // arrange
         String adocContent = "[source]\n" +
@@ -356,6 +375,17 @@ public class AsciidocConfluencePageTest {
 
         // assert
         String expectedContent = "<a href=\"http://www.foo.ch\"><ac:image ac:height=\"200\" ac:width=\"300\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></a>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithImageWithTitle_returnsConfluencePageContentWithImageWithTitle() {
+        String adocContent = ".A beautiful sunset\n" + 
+            "image::sunset.jpg[]";
+
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        String expectedContent = "<ac:image ac:title=\"A beautiful sunset\" ac:alt=\"A beautiful sunset\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image><div class=\"cp-image-title\"><em>Figure 1. A beautiful sunset</em></div>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -936,6 +966,23 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithUnorderedListAndTitle_returnsConfluencePageHavingCorrectUnorderedListAndTitleMarkup() {
+        // arrange
+        String adocContent = ".An unordered list title\n" + 
+                "* L1-1\n" +
+                "* L1-2\n";
+
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<div class=\"cp-ulist-title\"><em>An unordered list title</em></div>" + "<ul><li>L1-1</li><li>L1-2</li></ul>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithOrderedList_returnsConfluencePageHavingCorrectOrderedListMarkup() {
         // arrange
         String adocContent = ". L1-1\n" +
@@ -951,6 +998,23 @@ public class AsciidocConfluencePageTest {
 
         // assert
         String expectedContent = "<ol><li>L1-1<ol><li>L2-1<ol><li>L3-1<ol><li>L4-1<ol><li>L5-1</li></ol></li></ol></li></ol></li></ol></li><li>L1-2</li></ol>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithOrderedListAndTitle_returnsConfluencePageHavingCorrectOrderedListAndTitleMarkup() {
+        // arrange
+        String adocContent = ".An ordered list title\n" + 
+                ". L1-1\n" +
+                ". L1-2\n";
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<div class=\"cp-olist-title\"><em>An ordered list title</em></div>" + 
+            "<ol><li>L1-1</li><li>L1-2</li></ol>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/04-paragraphs.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/04-paragraphs.adoc
@@ -37,3 +37,12 @@ This is a paragraph with `*_monospaced bold italic_*` text.
 This is a paragraph with ^super^script and ~sub~script text.
 ....
 This is a paragraph with ^super^script and ~sub~script text.
+
+[listing]
+....
+.This the title of a paragraph
+The title of a paragraph will rendered using a custom CSS class `cp-para-title`
+....
+
+.This the title of a paragraph
+The title of a paragraph will rendered using a custom CSS class `cp-para-title`

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/04-paragraphs.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/04-paragraphs.adoc
@@ -41,8 +41,8 @@ This is a paragraph with ^super^script and ~sub~script text.
 [listing]
 ....
 .This the title of a paragraph
-The title of a paragraph will rendered using a custom CSS class `cp-para-title`
+The title of a paragraph will rendered using a custom CSS class `cp-paragraph-title`
 ....
 
 .This the title of a paragraph
-The title of a paragraph will rendered using a custom CSS class `cp-para-title`
+The title of a paragraph will rendered using a custom CSS class `cp-paragraph-title`

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/06-images.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/06-images.adoc
@@ -11,6 +11,16 @@ image::../images/frisbee.png[]
 
 image::../images/frisbee.png[]
 
+Also a caption can be set on an image by using a block title. The title is rendered with a custom CSS class `cp-image-title`.
+
+[listing]
+....
+.A nice orange frisbee
+image::../images/frisbee.png[]
+....
+
+.A nice orange frisbee
+image::../images/frisbee.png[]
 
 == Image Size
 

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
@@ -2,6 +2,8 @@
 
 AsciiDoc literal blocks, listing blocks and code blocks are converted to formatted blocks in Confluence.
 
+A title can be set for each type of block. The title is rendered as the title of confluence panel.
+
 == Literal Block
 
 Literal blocks are converted as pre-formatted text.
@@ -23,11 +25,13 @@ Listing blocks are converted using the "noformat" macro.
 
 [listing]
 ....
+.Title of the listing block
 ----
 this is a listing block
 ----
 ....
 
+.Title of the listing block
 ----
 this is a listing block
 ----

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
@@ -2,7 +2,7 @@
 
 AsciiDoc literal blocks, listing blocks and code blocks are converted to formatted blocks in Confluence.
 
-A title can be set for each type of block. The title is rendered as the title of confluence panel.
+A title can be set for each type of block. The title is rendered as the title of the Confluence panel.
 
 == Literal Block
 


### PR DESCRIPTION
this a pr for issue #145 .

It add title to block where the method exist.
I used h4 for most title, except h6 for image_block captioned title, which use h6.
