### PR TITLE
#148: add option to disable ssl by providing a custom SSLContext to HttpClientBuilder

### DIFF
--- a/asciidoc-confluence-publisher-cli/pom.xml
+++ b/asciidoc-confluence-publisher-cli/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/asciidoc-confluence-publisher-cli/pom.xml
+++ b/asciidoc-confluence-publisher-cli/pom.xml
@@ -46,7 +46,12 @@
             <artifactId>jackson-databind</artifactId>
             <scope>compile</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
@@ -61,11 +66,6 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/ArgumentsParserTest.java
+++ b/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/ArgumentsParserTest.java
@@ -100,4 +100,23 @@ public class ArgumentsParserTest {
         assertThat(value.get().get("attr1"), is("val1"));
         assertThat(value.get().get("attr2"), is("val2"));
     }
+
+    @Test
+    public void optionalBooleanArgument_valuePresent_returnsParsedValue() {
+        String[] args = { "enableNoValue", "enableWithValue=true", "disableWithValue=false"};
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertTrue(parser.optionalBooleanArgument("enableNoValue", args).orElse(false));
+        assertTrue(parser.optionalBooleanArgument("enableWithValue", args).orElse(false));
+        assertFalse(parser.optionalBooleanArgument("disableWithValue", args).orElse(true));
+    }
+
+    @Test
+    public void optionalBooleanArgument_valueNotPresent_returnsParsedValue() {
+        String[] args = { "otherFlag" };
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertFalse(parser.optionalBooleanArgument("disableNoValue", args).orElse(false));
+        assertTrue(parser.optionalBooleanArgument("disableNoValue", args).orElse(true));
+    }
 }

--- a/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/ArgumentsParser.java
+++ b/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/ArgumentsParser.java
@@ -35,11 +35,15 @@ class ArgumentsParser {
     }
 
 
-    boolean optionalBoolArgument(String key, String[] args) {
-        Optional<String> opt = stream(args)
-                .filter((keyAndValue) -> keyAndValue.startsWith(key))
-                .findFirst();
-        return opt.isPresent();
+    Optional<Boolean> optionalBooleanArgument(String key, String[] args) {
+        Optional<String> value = optionalArgument(key, args);
+        if (value.isPresent()) {
+            return value.map(val -> val.equalsIgnoreCase("true"));
+        }
+        return stream(args)
+            .filter((keyAndValue) -> keyAndValue.equals(key))
+            .findFirst()
+            .map(val -> true);
     }
 
 

--- a/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/ArgumentsParser.java
+++ b/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/ArgumentsParser.java
@@ -34,6 +34,15 @@ class ArgumentsParser {
                 .orElseThrow(() -> new IllegalArgumentException("mandatory argument '" + key + "' is missing"));
     }
 
+
+    boolean optionalBoolArgument(String key, String[] args) {
+        Optional<String> opt = stream(args)
+                .filter((keyAndValue) -> keyAndValue.startsWith(key))
+                .findFirst();
+        return opt.isPresent();
+    }
+
+
     Optional<String> optionalArgument(String key, String[] args) {
         return stream(args)
                 .filter((keyAndValue) -> keyAndValue.startsWith(key + "="))

--- a/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
+++ b/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
@@ -54,7 +54,7 @@ public class AsciidocConfluencePublisherCommandLineClient {
         String spaceKey = argumentsParser.mandatoryArgument("spaceKey", args);
         String ancestorId = argumentsParser.mandatoryArgument("ancestorId", args);
         String versionMessage = argumentsParser.optionalArgument("versionMessage", args).orElse(null);
-        boolean skipSslVerification = argumentsParser.optionalBoolArgument("skipSslVerification", args);
+        boolean skipSslVerification = argumentsParser.optionalBooleanArgument("skipSslVerification", args).orElse(false);
         
         PublishingStrategy publishingStrategy = PublishingStrategy.valueOf(argumentsParser.optionalArgument("strategy", args).orElse(APPEND_TO_ANCESTOR.name()));
 

--- a/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
+++ b/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
@@ -54,7 +54,7 @@ public class AsciidocConfluencePublisherCommandLineClient {
         String spaceKey = argumentsParser.mandatoryArgument("spaceKey", args);
         String ancestorId = argumentsParser.mandatoryArgument("ancestorId", args);
         String versionMessage = argumentsParser.optionalArgument("versionMessage", args).orElse(null);
-        boolean skipSslVerification = optionalBoolArgument("skipSslVerification", args);
+        boolean skipSslVerification = argumentsParser.optionalBoolArgument("skipSslVerification", args);
         
         PublishingStrategy publishingStrategy = PublishingStrategy.valueOf(argumentsParser.optionalArgument("strategy", args).orElse(APPEND_TO_ANCESTOR.name()));
 
@@ -80,13 +80,6 @@ public class AsciidocConfluencePublisherCommandLineClient {
         } finally {
             deleteDirectory(buildFolder);
         }
-    }
-
-    private static boolean optionalBoolArgument(String key, String[] args) {
-        Optional<String> opt = stream(args)
-            .filter((keyAndValue) -> keyAndValue.startsWith(key))
-            .findFirst();
-        return opt.isPresent();
     }
 
     private static void deleteDirectory(Path buildFolder) throws IOException {

--- a/asciidoc-confluence-publisher-client/src/it/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisherIntegrationTest.java
+++ b/asciidoc-confluence-publisher-client/src/it/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisherIntegrationTest.java
@@ -219,7 +219,7 @@ public class ConfluencePublisherIntegrationTest {
     }
 
     private static ConfluenceRestClient confluenceRestClient() {
-        return new ConfluenceRestClient("http://localhost:8090", "confluence-publisher-it", "1234");
+        return new ConfluenceRestClient("http://localhost:8090", false, "confluence-publisher-it", "1234");
     }
 
 }

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClient.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClient.java
@@ -63,8 +63,8 @@ public class ConfluenceRestClient implements ConfluenceClient {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final HttpRequestFactory httpRequestFactory;
 
-    public ConfluenceRestClient(String rootConfluenceUrl, boolean disableSSLVerfication, String username, String password) {
-        this(rootConfluenceUrl, defaultHttpClient(disableSSLVerfication), username, password);
+    public ConfluenceRestClient(String rootConfluenceUrl, boolean disableSslVerfication, String username, String password) {
+        this(rootConfluenceUrl, defaultHttpClient(disableSslVerfication), username, password);
     }
 
     public ConfluenceRestClient(String rootConfluenceUrl, CloseableHttpClient httpClient, String username, String password) {
@@ -377,7 +377,7 @@ public class ConfluenceRestClient implements ConfluenceClient {
         }
     }
 
-    private static CloseableHttpClient defaultHttpClient(boolean disableSSLVerfication) {
+    private static CloseableHttpClient defaultHttpClient(boolean disableSslLVerfication) {
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectionRequestTimeout(20 * 1000)
                 .setConnectTimeout(20 * 1000)
@@ -386,7 +386,7 @@ public class ConfluenceRestClient implements ConfluenceClient {
         HttpClientBuilder builder = HttpClients.custom()
                 .setDefaultRequestConfig(requestConfig);
 
-        if (disableSSLVerfication) {
+        if (disableSslLVerfication) {
             builder.setSSLContext(emptySSLContext());
         }
         return builder.build();

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -79,6 +79,7 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
         <asciidocRootFolder>etc/docs</asciidocRootFolder>
         <sourceEncoding>UTF-8<sourceEncoding> <!-- default -->
         <rootConfluenceUrl>http://localhost:8090</rootConfluenceUrl>
+        <skipSslVerification>false</skipSslVerification>
         <spaceKey>SPACE</spaceKey>
         <ancestorId>327706</ancestorId>
         <username>username</username> <!-- or read from property -->
@@ -107,9 +108,15 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
 | The encoding of the AsciiDoc files.
 | optional (defaults to UTF-8)
 
+| skipSslVerification
+| switch to disable SSL certificates verification when connecting to an HTTPS Confluence 
+  server. Possible values: `true` or `false`
+| optional (default to `false`)
+
 | rootConfluenceUrl
 | The root URL of the Confluence instance to publish to.
 | mandatory
+
 
 | spaceKey
 | The key of the Confluence space to publish to.
@@ -258,6 +265,7 @@ The following command shows an example for publishing AsciiDoc sources via the C
 
 ----
 docker run --rm -e ROOT_CONFLUENCE_URL=http://confluence-host \
+   -e SKIP_SSL_VERIFICATION=false \
    -e USERNAME=username \
    -e PASSWORD=1234 \
    -e SPACE_KEY=XYZ \

--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -8,6 +8,7 @@ VOLUME /var/asciidoc-root-folder
 
 ENV SOURCE_ENCODING="" \
     ROOT_CONFLUENCE_URL=""  \
+    SKIP_SSL_VERIFICATION="false" \
     SPACE_KEY=""  \
     ANCESTOR_ID=""  \
     USERNAME=""  \
@@ -22,6 +23,7 @@ ENTRYPOINT ["sh", "-c", "java -jar /opt/asciidoc-confluence-publisher-docker.jar
     \"asciidocRootFolder=/var/asciidoc-root-folder\" \
     \"sourceEncoding=$SOURCE_ENCODING\" \
     \"rootConfluenceUrl=$ROOT_CONFLUENCE_URL\" \
+    \"skipSslVerification=${SKIP_SSL_VERIFICATION}\" \
     \"spaceKey=$SPACE_KEY\" \
     \"ancestorId=$ANCESTOR_ID\" \
     \"username=$USERNAME\" \

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -85,6 +85,9 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean skip;
 
+    @Parameter(defaultValue = "false")
+    private boolean skipSslVerification;
+
     @Parameter
     private Map<String, Object> attributes;
 
@@ -104,7 +107,7 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
             Map<String, Object> attributes = this.attributes != null ? this.attributes : emptyMap();
             ConfluencePublisherMetadata confluencePublisherMetadata = asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, pageTitlePostProcessor, this.confluencePublisherBuildFolder.toPath(), attributes);
 
-            ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(this.rootConfluenceUrl, this.username, this.password);
+            ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(this.rootConfluenceUrl, this.skipSslVerification, this.username, this.password);
             ConfluencePublisherListener confluencePublisherListener = new LoggingConfluencePublisherListener(getLog());
 
             ConfluencePublisher confluencePublisher = new ConfluencePublisher(confluencePublisherMetadata, this.publishingStrategy, confluenceRestClient, confluencePublisherListener, this.versionMessage);


### PR DESCRIPTION
The PR modify ConfluenceRestClient to accept a configuration switch in its constructor that enable/disable SSL verification "skipping".

If disabled the HTTPClient of ConfluenceRestClient is build as usual
If enabled the HTTClient is build with a empty SSLContext, i.e. a context that does not validate the proposed certificate.