### PR TITLE
Remove guava from dependencies

### DIFF
--- a/asciidoc-confluence-publisher-maven-plugin/pom.xml
+++ b/asciidoc-confluence-publisher-maven-plugin/pom.xml
@@ -43,11 +43,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -103,12 +103,6 @@
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>18.0</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.9</version>


### PR DESCRIPTION
Looks like it is not used nor in the publisher neither transitively by other dependencies.