### PR TITLE
Support for internal cross references to sections

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/section.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/section.html.slim
@@ -1,3 +1,6 @@
 *{tag: %(h#{section_level})}
-  = section_title
-= content
+  ac:structured-macro ac:name="anchor"
+    ac:parameter ac:name=""
+     =(anchor_name id)
+  =section_title
+=content

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -336,11 +336,11 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1>Title level 1</h1>" +
-                "<h2>Title level 2</h2>" +
-                "<h3>Title level 3</h3>" +
-                "<h4>Title level 4</h4>" +
-                "<h5>Title level 5</h5>";
+        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_1</ac:parameter></ac:structured-macro>Title level 1</h1>" +
+                "<h2><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_2</ac:parameter></ac:structured-macro>Title level 2</h2>" +
+                "<h3><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_3</ac:parameter></ac:structured-macro>Title level 3</h3>" +
+                "<h4><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_4</ac:parameter></ac:structured-macro>Title level 4</h4>" +
+                "<h5><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_5</ac:parameter></ac:structured-macro>Title level 5</h5>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1089,19 +1089,55 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
-    public void renderConfluencePage_asciiDocWithInternalCrossReferenceToSection_returnsConfluencePageContentWithInternalCrossReferenceToSectionUsingSectionTitle() {
+    public void renderConfluencePage_asciiDocWithInternalCrossReferenceToSectionWithBlockAnchor_returnsConfluencePageContentWithInternalCrossReferenceToSectionUsingBlockAnchor() {
         // arrange
         String adocContent = "" +
-                "== Section 1 [[section1]]\n" +
-                "Cross reference to <<section1>>";
+                "[[section-1]]\n" +
+                "== Section 1\n" +
+                "Cross reference to <<section-1>>";
 
         // act
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "" +
-                "<h1>Section 1</h1>" +
-                "<p>Cross reference to <ac:link ac:anchor=\"section1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
+                "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+                "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithInternalCrossReferenceToSectionWithCustomId_returnsConfluencePageContentWithInternalCrossReferenceToSectionUsingCustomId() {
+        // arrange
+        String adocContent = "" +
+                "[#section-1]\n" +
+                "== Section 1\n" +
+                "Cross reference to <<section-1>>";
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "" +
+                "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+                "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithInternalCrossReferenceInlineToSectionWithInlineAnchor_returnsConfluencePageContentWithInternalCrossReferenceToSectionUsingSectionTitle() {
+        // arrange
+        String adocContent = "" +
+                "== Section 1 [[section-1]]\n" +
+                "Cross reference to <<section-1>>";
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "" +
+                "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+                "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1109,16 +1145,16 @@ public class AsciidocConfluencePageTest {
     public void renderConfluencePage_asciiDocWithInternalCrossReferenceToSectionAndCustomLabel_returnsConfluencePageContentWithInternalCrossReferenceToSectionUsingCustomLabel() {
         // arrange
         String adocContent = "" +
-                "== Section 1 [[section1]]\n" +
-                "Cross reference to <<section1,section 1>>";
+                "== Section 1 [[section-1]]\n" +
+                "Cross reference to <<section-1,section 1>>";
 
         // act
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "" +
-                "<h1>Section 1</h1>" +
-                "<p>Cross reference to <ac:link ac:anchor=\"section1\"><ac:plain-text-link-body><![CDATA[section 1]]></ac:plain-text-link-body></ac:link></p>";
+                "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+                "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/01-pages.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/01-pages.adoc
@@ -30,7 +30,7 @@ referencing AsciiDoc file. All referenced AsciiDoc files must be placed below th
 
 == Links within Pages
 
-Links within pages in Confluence are supported using AsciiDoc inline anchors and internal cross references:
+Links to content blocks within the same page are supported using AsciiDoc inline anchors and internal cross references:
 
 [listing]
 ....
@@ -42,6 +42,34 @@ Another paragraph with internal cross-reference to <<paragraph-a>>
 [[paragraph-a]]Paragraph with inline anchor
 
 Another paragraph with internal cross-reference to <<paragraph-a>>
+
+Links to sections within the same page are supported either using anchors or custom section ids:
+
+[listing]
+....
+[[section-a]]
+=== Section with Anchor
+
+Paragraph with internal cross-reference to <<section-a>>
+....
+
+[[section-a]]
+=== Section with Anchor
+
+Paragraph with internal cross-reference to <<section-a>>
+
+[listing]
+....
+[#section-b]
+=== Section with Custom Id
+
+Paragraph with internal cross-reference to <<section-b>>
+....
+
+[#section-b]
+=== Section with Custom Id
+
+Paragraph with internal cross-reference to <<section-b>>
 
 
 [WARNING]


### PR DESCRIPTION
Resolves #165 (for internal cross references with same Confluence page only).

Note: applying this PR will add anchors to all section titles (independent whether custom anchors or ids are defined) and thus, will lead to re-publication of all existing pages after upgrade.