### PR TITLE
Fix for publishing strategy with Docker image-based publishing 

### DIFF
--- a/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
+++ b/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
@@ -55,7 +55,7 @@ public class AsciidocConfluencePublisherCommandLineClient {
         String spaceKey = argumentsParser.mandatoryArgument("spaceKey", args);
         String ancestorId = argumentsParser.mandatoryArgument("ancestorId", args);
         String versionMessage = argumentsParser.optionalArgument("versionMessage", args).orElse(null);
-        PublishingStrategy publishingStrategy = PublishingStrategy.valueOf(argumentsParser.optionalArgument("strategy", args).orElse(APPEND_TO_ANCESTOR.name()));
+        PublishingStrategy publishingStrategy = PublishingStrategy.valueOf(argumentsParser.optionalArgument("publishingStrategy", args).orElse(APPEND_TO_ANCESTOR.name()));
 
         Path documentationRootFolder = Paths.get(argumentsParser.mandatoryArgument("asciidocRootFolder", args));
         Path buildFolder = createTempDirectory("confluence-publisher");


### PR DESCRIPTION
Fixes #171 

(Automated tests are part of branch https://github.com/confluence-publisher/confluence-publisher/tree/feature/integration-tests-for-docker-based-publishing, but are currently blocked due to issues with resolving Docker host address from "inside" on CircleCI)