### PR TITLE
Table of Contents

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/_toc.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/_toc.html.slim
@@ -1,0 +1,3 @@
+ac:structured-macro ac:name="toc"
+  ac:parameter ac:name="maxLevel"
+    =2

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/_toc.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/_toc.html.slim
@@ -1,3 +1,3 @@
 ac:structured-macro ac:name="toc"
   ac:parameter ac:name="maxLevel"
-    =2
+    =((attr? :toclevels) ? (attr :toclevels) : 2)

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_toc.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_toc.html.slim
@@ -1,0 +1,1 @@
+include _toc.html

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/embedded.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/embedded.html.slim
@@ -1,0 +1,4 @@
+- if (attr? :toc) && (attr? 'toc-placement', 'auto')
+  include _toc.html
+
+=content

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/embedded.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/embedded.html.slim
@@ -1,4 +1,5 @@
 - if (attr? :toc) && (attr? 'toc-placement', 'auto')
-  include _toc.html
+  p
+    include _toc.html
 
 =content

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1239,9 +1239,11 @@ public class AsciidocConfluencePageTest {
 
         // assert
         String expectedContent = "" +
+                "<p>" +
                 "<ac:structured-macro ac:name=\"toc\">" +
                 "<ac:parameter ac:name=\"maxLevel\">2</ac:parameter>" +
-                "</ac:structured-macro>";
+                "</ac:structured-macro>" +
+                "</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1257,9 +1259,11 @@ public class AsciidocConfluencePageTest {
 
         // assert
         String expectedContent = "" +
+                "<p>" +
                 "<ac:structured-macro ac:name=\"toc\">" +
                 "<ac:parameter ac:name=\"maxLevel\">4</ac:parameter>" +
-                "</ac:structured-macro>";
+                "</ac:structured-macro>" +
+                "</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1229,6 +1229,43 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithTableOfContentsAsAttribute_returnsConfluencePageContentWithTableOfContentsMacro() {
+        // arrange
+        String adocContent = "" +
+                "= Page Title\n" +
+                ":toc: auto\n";
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "" +
+                "<ac:structured-macro ac:name=\"toc\">" +
+                "<ac:parameter ac:name=\"maxLevel\">2</ac:parameter>" +
+                "</ac:structured-macro>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithTableOfContentsAsMacro_returnsConfluencePageContentWithTableOfContentsMacro() {
+        // arrange
+        String adocContent = "" +
+                "= Page Title\n" +
+                ":toc: macro\n" +
+                "\n" +
+                "toc::[]";
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "" +
+                "<ac:structured-macro ac:name=\"toc\">" +
+                "<ac:parameter ac:name=\"maxLevel\">2</ac:parameter>" +
+                "</ac:structured-macro>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void attachments_asciiDocWithImage_returnsImageAsAttachmentWithPathAndName() {
         // arrange
         String adocContent = "image::sunset.jpg[]";

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1246,6 +1246,24 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithTableOfContentsAsAttributeWithCustomDepth_returnsConfluencePageContentWithTableOfContentsMacroWithCustomDepth() {
+        // arrange
+        String adocContent = "" +
+                "= Page Title\n" +
+                ":toc: auto\n" +
+                ":toclevels: 4\n";
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "" +
+                "<ac:structured-macro ac:name=\"toc\">" +
+                "<ac:parameter ac:name=\"maxLevel\">4</ac:parameter>" +
+                "</ac:structured-macro>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithTableOfContentsAsMacro_returnsConfluencePageContentWithTableOfContentsMacro() {
         // arrange
         String adocContent = "" +
@@ -1261,6 +1279,27 @@ public class AsciidocConfluencePageTest {
         String expectedContent = "" +
                 "<ac:structured-macro ac:name=\"toc\">" +
                 "<ac:parameter ac:name=\"maxLevel\">2</ac:parameter>" +
+                "</ac:structured-macro>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithTableOfContentsAsMacroWithCustomDepth_returnsConfluencePageContentWithTableOfContentsMacroWithCustomDepth() {
+        // arrange
+        String adocContent = "" +
+                "= Page Title\n" +
+                ":toc: macro\n" +
+                ":toclevels: 4\n" +
+                "\n" +
+                "toc::[]";
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "" +
+                "<ac:structured-macro ac:name=\"toc\">" +
+                "<ac:parameter ac:name=\"maxLevel\">4</ac:parameter>" +
                 "</ac:structured-macro>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -28,6 +28,7 @@ Currently, the Confluence Publisher supports the following AsciiDoc features:
 * <<00-index/09-external-links.adoc#, External Links>>
 * <<00-index/10-plantuml.adoc#, PlantUML>>
 * <<00-index/11-attachments.adoc#, Attachments>>
+* <<00-index/12-table-of-contents.adoc#, Table of Contents>>
 
 The Confluence Publisher uses AsciidoctorJ and therefore supports documentation written using the Asciidoctor syntax.
 See link:http://asciidoctor.org/docs/user-manual/[Asciidoctor User Manual] for more information about Asciidoctor.

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/12-table-of-contents.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/12-table-of-contents.adoc
@@ -1,0 +1,62 @@
+= Table of Contents
+:toc:
+
+AsciiDoc table of contents are converted to the table of contents macro of Confluence. The table of contents displays
+the tree of sections for a specific page.
+
+Table of contents can either be displayed at the very top of a page (default
+mode), or at a custom-defined location within the page (macro mode):
+
+
+== Table of Contents (Default)
+
+Displaying the table of contents at the top of a page can be done by specifying the `toc` AsciiDoc attribute:
+
+[listing]
+....
+= Page Title
+:toc:
+
+== Some Section
+....
+
+The `toc` attribute must follow the title without any additional empty line.
+
+
+== Table of Contents (Macro)
+
+Displaying the table of contents in any location other than the top of the page requires the `toc` AsciiDoc attribute
+to be set to `macro`. Once done, the table of content can be displayed in the requested location using the `toc::[]`
+macro:
+
+[listing]
+....
+= Page Title
+:toc: macro
+
+== Some Section
+
+toc::[]
+....
+
+The `toc::[]` macro must be surrounded by empty lines for the table of contents to be displayed.
+
+
+== Levels
+
+By default, sections of level 1 and 2 are contained in the table of contents. The number of levels displayed can be
+customized using the `toclevels` attribute (for both default and macro mode):
+
+[listing]
+....
+= Page Title
+:toc:
+:toclevels: 4
+
+== Some Section
+....
+
+[NOTE]
+====
+Specifying a title for the table of contents is currently not supported.
+====


### PR DESCRIPTION
- ToC based on "toc" Confluence macro
- default (top of page) and macro mode (within page content)
- support for custom levels

Closes #87 