### PR TITLE
Improved error logging

### DIFF
--- a/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClientIntegrationTest.java
+++ b/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClientIntegrationTest.java
@@ -232,7 +232,7 @@ public class AsciidocConfluencePublisherCommandLineClientIntegrationTest {
     }
 
     private static void startProxy(String dockerImageName, String proxyHost, int proxyPort, Map<String, String> env, PortAwareRunnable runnable) throws Exception {
-        try (GenericContainer proxy = new GenericContainer(dockerImageName)
+        try (GenericContainer<?> proxy = new GenericContainer<>(dockerImageName)
                 .withEnv(env)
                 .withNetwork(SHARED)
                 .withNetworkAliases(proxyHost)

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClient.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClient.java
@@ -206,7 +206,7 @@ public class ConfluenceRestClient implements ConfluenceClient {
         return sendRequest(request, (response) -> {
             StatusLine statusLine = response.getStatusLine();
             if (statusLine.getStatusCode() < 200 || statusLine.getStatusCode() > 206) {
-                throw new RequestFailedException(request, response);
+                throw new RequestFailedException(request, response, null);
             }
 
             return responseHandler.apply(response);
@@ -219,7 +219,7 @@ public class ConfluenceRestClient implements ConfluenceClient {
         try (CloseableHttpResponse response = this.httpClient.execute(httpRequest)) {
             return responseHandler.apply(response);
         } catch (IOException e) {
-            throw new RuntimeException("Request could not be sent" + httpRequest, e);
+            throw new RequestFailedException(httpRequest, null, e);
         }
     }
 

--- a/asciidoc-confluence-publisher-docker/src/it/java/org/sahli/asciidoc/confluence/publisher/docker/DockerBasedPublishingIntegrationTest.java
+++ b/asciidoc-confluence-publisher-docker/src/it/java/org/sahli/asciidoc/confluence/publisher/docker/DockerBasedPublishingIntegrationTest.java
@@ -210,7 +210,7 @@ public class DockerBasedPublishingIntegrationTest {
     }
 
     private static void publishAndVerify(String pathToContent, Map<String, String> env, Runnable runnable) {
-        try (GenericContainer publisher = new GenericContainer("confluencepublisher/confluence-publisher:0.0.0-SNAPSHOT")
+        try (GenericContainer<?> publisher = new GenericContainer<>("confluencepublisher/confluence-publisher:0.0.0-SNAPSHOT")
                 .withEnv(env)
                 .withNetwork(SHARED)
                 .withClasspathResourceMapping("/" + pathToContent, "/var/asciidoc-root-folder", READ_ONLY)
@@ -253,7 +253,7 @@ public class DockerBasedPublishingIntegrationTest {
     }
 
     private static void startProxy(String dockerImageName, String proxyHost, int proxyPort, Map<String, String> env, Runnable runnable) {
-        try (GenericContainer proxy = new GenericContainer(dockerImageName)
+        try (GenericContainer<?> proxy = new GenericContainer<>(dockerImageName)
                 .withEnv(env)
                 .withNetwork(SHARED)
                 .withNetworkAliases(proxyHost)

--- a/asciidoc-confluence-publisher-maven-plugin/src/it/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojoIntegrationTest.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/it/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojoIntegrationTest.java
@@ -266,7 +266,7 @@ public class AsciidocConfluencePublisherMojoIntegrationTest {
     }
 
     private static void startProxy(String dockerImageName, String proxyHost, int proxyPort, Map<String, String> env, PortAwareRunnable runnable) throws Exception {
-        try (GenericContainer proxy = new GenericContainer(dockerImageName)
+        try (GenericContainer<?> proxy = new GenericContainer<>(dockerImageName)
                 .withEnv(env)
                 .withNetwork(SHARED)
                 .withNetworkAliases(proxyHost)

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -130,7 +130,12 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
             ConfluencePublisher confluencePublisher = new ConfluencePublisher(confluencePublisherMetadata, this.publishingStrategy, confluenceRestClient, confluencePublisherListener, this.versionMessage);
             confluencePublisher.publish();
         } catch (Exception e) {
-            getLog().error("Publishing to Confluence failed: " + e.getMessage());
+            if (getLog().isDebugEnabled()) {
+                getLog().debug("Publishing to Confluence failed", e);
+            } else {
+                getLog().error("Publishing to Confluence failed: " + e.getMessage());
+            }
+
             throw new MojoExecutionException("Publishing to Confluence failed", e);
         }
     }


### PR DESCRIPTION
Streamlines and improves logging in case of error while publishing, either due to non-200 responses from Confluence, or due to connection issues.

In addition, full stack traces are now logged when debug log level is enabled in Maven (using `-X`)

Resolves #223 