### PR TITLE
Line numbers for source blocks

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_listing.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_listing.html.slim
@@ -6,6 +6,8 @@
       ac:parameter ac:name="title" #{title}
     - if attr? :linenums
       ac:parameter ac:name="linenumbers" true
+    - if attr? :start
+      ac:parameter ac:name="firstline" =(attr :start)
     ac:plain-text-body
       <![CDATA[#{content}]]>
 - else

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_listing.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_listing.html.slim
@@ -4,6 +4,8 @@
       ac:parameter ac:name="language" #{source_lang}
     - if title?
       ac:parameter ac:name="title" #{title}
+    - if attr? :linenums
+      ac:parameter ac:name="linenumbers" true
     ac:plain-text-body
       <![CDATA[#{content}]]>
 - else

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -229,7 +229,7 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
-    public void renderConfluencePage_asciiDocWithJavaSourceListing_returnsConfluencePageContentWithMacroWithNameCodeAndParameterJava() {
+    public void renderConfluencePage_asciiDocWithJavaSourceListing_returnsConfluencePageContentWithMacroWithJavaParameter() {
         // arrange
         String adocContent = "[source,java]\n" +
                 "----\n" +
@@ -242,6 +242,65 @@ public class AsciidocConfluencePageTest {
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
                 "<ac:parameter ac:name=\"language\">java</ac:parameter>" +
+                "<ac:plain-text-body><![CDATA[import java.util.List;]]></ac:plain-text-body>" +
+                "</ac:structured-macro>";
+        assertThat(asciiDocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithSourceListingWithLineNumbers_returnsConfluencePageContentWithMacroWithLineNumbersParameter() {
+        // arrange
+        String adocContent = "[source%linenums]\n" +
+                "----\n" +
+                "import java.util.List;\n" +
+                "----";
+
+        // act
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
+                "<ac:parameter ac:name=\"linenumbers\">true</ac:parameter>" +
+                "<ac:plain-text-body><![CDATA[import java.util.List;]]></ac:plain-text-body>" +
+                "</ac:structured-macro>";
+        assertThat(asciiDocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithSourceListingWithLineNumbersAndJavaLanguage_returnsConfluencePageContentWithMacroWithLineNumbersAndJavaParameter() {
+        // arrange
+        String adocContent = "[source,java,linenums]\n" +
+                "----\n" +
+                "import java.util.List;\n" +
+                "----";
+
+        // act
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
+                "<ac:parameter ac:name=\"language\">java</ac:parameter>" +
+                "<ac:parameter ac:name=\"linenumbers\">true</ac:parameter>" +
+                "<ac:plain-text-body><![CDATA[import java.util.List;]]></ac:plain-text-body>" +
+                "</ac:structured-macro>";
+        assertThat(asciiDocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithSourceListingWithGlobalLineNumbersAttribute_returnsConfluencePageContentWithMacroWithLineNumbersParameter() {
+        // arrange
+        String adocContent = ":source-linenums-option:\n" +
+                "[source]\n" +
+                "----\n" +
+                "import java.util.List;\n" +
+                "----";
+
+        // act
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
+                "<ac:parameter ac:name=\"linenumbers\">true</ac:parameter>" +
                 "<ac:plain-text-body><![CDATA[import java.util.List;]]></ac:plain-text-body>" +
                 "</ac:structured-macro>";
         assertThat(asciiDocConfluencePage.content(), is(expectedContent));

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -287,6 +287,26 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithSourceListingWithLineNumbersAndStartIndex_returnsConfluencePageContentWithMacroWithLineNumbersAndFirstLineParameter() {
+        // arrange
+        String adocContent = "[source%linenums,start=3]\n" +
+                "----\n" +
+                "import java.util.List;\n" +
+                "----";
+
+        // act
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
+                "<ac:parameter ac:name=\"linenumbers\">true</ac:parameter>" +
+                "<ac:parameter ac:name=\"firstline\">3</ac:parameter>" +
+                "<ac:plain-text-body><![CDATA[import java.util.List;]]></ac:plain-text-body>" +
+                "</ac:structured-macro>";
+        assertThat(asciiDocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithSourceListingWithGlobalLineNumbersAttribute_returnsConfluencePageContentWithMacroWithLineNumbersParameter() {
         // arrange
         String adocContent = ":source-linenums-option:\n" +

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
@@ -137,6 +137,26 @@ line two
 line three
 ----
 
+A custom start line number for a source block can be specified using the `start` option:
+
+[listing]
+....
+[source,java,linenums,start=4]
+----
+public class MyCode {
+    // comment
+}
+----
+....
+
+[source,java,linenums,start=4]
+----
+public class MyCode {
+    // comment
+}
+----
+
+
 [WARNING]
 ====
 Other advanced features like listing file names or callouts are not supported.

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
@@ -96,6 +96,47 @@ Restricting the source code to be included based on tags is supported:
 include::../files/SourceWithMethodTag.java[tags=myMethod]
 ----
 
+== Line Numbers
+
+Line numbers for source code blocks can be enabled either using the `:source-linenums-option:` attribute globally for
+all source blocks on the page, or per source block using the `linenums` option:
+
+[listing]
+....
+[source,java,linenums]
+----
+public class MyCode {
+    // comment
+}
+----
+....
+
+[source,java,linenums]
+----
+public class MyCode {
+    // comment
+}
+----
+
+In case no source language is specified for the source block, line numbers have to be enabled using `[source%linenums]` (not `[source,linenums]`):
+
+[listing]
+....
+[source%linenums]
+----
+line one
+line two
+line three
+----
+....
+
+[source%linenums]
+----
+line one
+line two
+line three
+----
+
 [WARNING]
 ====
 Other advanced features like listing file names or callouts are not supported.


### PR DESCRIPTION
Adds support for enabling line numbers for source blocks using `linenums` (per source block)  or `:source-linenums-option:` (per page), and for specifying a custom line number start index using the `start` block attribute.

Resolves #215 