### PR TITLE
Neutralize potentially existing source highlighter

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
@@ -201,6 +201,7 @@ public class AsciidocConfluencePage {
         Map<String, Object> attributes = new HashMap<>(userAttributes);
         attributes.put("imagesoutdir", generatedAssetsTargetFolder.toString());
         attributes.put("outdir", generatedAssetsTargetFolder.toString());
+        attributes.put("source-highlighter", "none");
 
         return OptionsBuilder.options()
                 .backend("xhtml5")

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -403,6 +403,26 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithSourceListingAndSourceHighlighter_returnsConfluencePageContentWithoutSourceHighlighting() {
+        // arrange
+        String adocContent = ":source-highlighter: coderay\n" +
+                "[source,java]\n" +
+                "----\n" +
+                "import java.util.List;\n" +
+                "----";
+
+        // act
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
+                "<ac:parameter ac:name=\"language\">java</ac:parameter>" +
+                "<ac:plain-text-body><![CDATA[import java.util.List;]]></ac:plain-text-body>" +
+                "</ac:structured-macro>";
+        assertThat(asciiDocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithAllPossibleSectionLevels_returnsConfluencePageContentWithAllSectionHavingCorrectMarkup() {
         // arrange
         String adocContent = "= Title level 0\n\n" +

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
@@ -157,6 +157,13 @@ public class MyCode {
 ----
 
 
+== Source Highlighting
+
+AsciiDoc source highlighters (e.g. CodeRay) are not supported, in favor of using the source highlighting
+support of Confluence. Thus, any configured AsciiDoc source highlighter is automatically disabled when publishing to
+Confluence.
+
+
 [WARNING]
 ====
 Other advanced features like listing file names or callouts are not supported.


### PR DESCRIPTION
As Confluence is not able to properly display the source highlighting information for AsciiDoc source highlighters, source highlighters should have no effect when publishing to Confluence, instead relying on the internal source highlighting mechanism of Confluence.

Resolves #216 