### PR TITLE
feat: add rate limiter for http requests

### DIFF
--- a/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClientIntegrationTest.java
+++ b/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClientIntegrationTest.java
@@ -128,6 +128,28 @@ public class AsciidocConfluencePublisherCommandLineClientIntegrationTest {
     }
 
     @Test
+    public void publish_withMaxRequestsPerSecond() throws Exception {
+        // arrange
+        String[] args = {
+                "rootConfluenceUrl=http://localhost:8090",
+                "username=confluence-publisher-it",
+                "password=1234",
+                "spaceKey=CPI",
+                "ancestorId=327706",
+                "asciidocRootFolder=src/it/resources/default",
+                "maxRequestsPerSecond=1"
+        };
+
+        // act
+        AsciidocConfluencePublisherCommandLineClient.main(args);
+
+        // assert
+        givenAuthenticatedAsPublisher()
+                .when().get(childPagesFor("327706"))
+                .then().body("results.title", hasItem("Index"));
+    }
+
+    @Test
     public void publish_proxySchemeHostAndPortProvided_publishesDocumentationViaProxyToConfluence() throws Exception {
         // arrange
         withForwardProxyEnabled("localhost", 8443, (proxyPort) -> {

--- a/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
+++ b/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
@@ -57,6 +57,7 @@ public class AsciidocConfluencePublisherCommandLineClient {
         String spaceKey = argumentsParser.mandatoryArgument("spaceKey", args);
         String ancestorId = argumentsParser.mandatoryArgument("ancestorId", args);
         String versionMessage = argumentsParser.optionalArgument("versionMessage", args).orElse(null);
+        Integer maxRequestsPerSecond = argumentsParser.optionalArgument("maxRequestsPerSecond", args).map((value) -> parseInt(value)).orElse(null);
         PublishingStrategy publishingStrategy = PublishingStrategy.valueOf(argumentsParser.optionalArgument("publishingStrategy", args).orElse(APPEND_TO_ANCESTOR.name()));
 
         Path documentationRootFolder = Paths.get(argumentsParser.mandatoryArgument("asciidocRootFolder", args));
@@ -83,6 +84,8 @@ public class AsciidocConfluencePublisherCommandLineClient {
             ProxyConfiguration proxyConfiguration = new ProxyConfiguration(proxyScheme, proxyHost, proxyPort, proxyUsername, proxyPassword);
 
             ConfluenceRestClient confluenceClient = new ConfluenceRestClient(rootConfluenceUrl, proxyConfiguration, skipSslVerification, username, password);
+            confluenceClient.setMaxRequestsPerSecond(maxRequestsPerSecond);
+
             ConfluencePublisher confluencePublisher = new ConfluencePublisher(confluencePublisherMetadata, publishingStrategy, confluenceClient, new SystemOutLoggingConfluencePublisherListener(), versionMessage);
             confluencePublisher.publish();
         } finally {

--- a/asciidoc-confluence-publisher-client/pom.xml
+++ b/asciidoc-confluence-publisher-client/pom.xml
@@ -82,6 +82,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>22.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceClient.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceClient.java
@@ -24,6 +24,8 @@ import java.util.List;
  */
 public interface ConfluenceClient {
 
+    void setMaxRequestsPerSecond(Integer maxRequestsPerSecond);
+
     String addPageUnderAncestor(String spaceKey, String ancestorId, String title, String content, String versionMessage);
 
     void updatePage(String contentId, String ancestorId, String title, String content, int newVersion, String versionMessage);

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -81,6 +81,7 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
         <sourceEncoding>UTF-8<sourceEncoding> <!-- default -->
         <rootConfluenceUrl>http://localhost:8090</rootConfluenceUrl>
         <skipSslVerification>false</skipSslVerification>
+        <maxRequestsPerSecond>10</maxRequestsPerSecond>
         <spaceKey>SPACE</spaceKey>
         <ancestorId>327706</ancestorId>
         <username>username</username> <!-- or read from property -->
@@ -120,6 +121,10 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
 | Defines whether to disable SSL certificate verification when connecting to Confluence via HTTPS while using self-
   signed certificates.
 | optional (defaults to `false`)
+
+| maxRequestsPerSecond
+| Defines the number of REST API calls to execute within a second.
+| optional (defaults to unlimited calls)
 
 | spaceKey
 | The key of the Confluence space to publish to.
@@ -299,6 +304,7 @@ The following command shows an example for publishing AsciiDoc sources via the C
 ----
 docker run --rm -e ROOT_CONFLUENCE_URL=http://confluence-host \
    -e SKIP_SSL_VERIFICATION=false \
+   -e MAX_REQUESTS_PER_SECOND=10 \
    -e USERNAME=username \
    -e PASSWORD=1234 \
    -e SPACE_KEY=XYZ \

--- a/asciidoc-confluence-publisher-docker/publish.sh
+++ b/asciidoc-confluence-publisher-docker/publish.sh
@@ -4,6 +4,7 @@ exec java -jar /opt/asciidoc-confluence-publisher-docker.jar \
     sourceEncoding="$SOURCE_ENCODING" \
     rootConfluenceUrl="$ROOT_CONFLUENCE_URL" \
     skipSslVerification="$SKIP_SSL_VERIFICATION" \
+    maxRequestsPerSecond="$MAX_REQUESTS_PER_SECOND" \
     spaceKey="$SPACE_KEY" \
     ancestorId="$ANCESTOR_ID" \
     username="$USERNAME" \

--- a/asciidoc-confluence-publisher-docker/src/it/java/org/sahli/asciidoc/confluence/publisher/docker/DockerBasedPublishingIntegrationTest.java
+++ b/asciidoc-confluence-publisher-docker/src/it/java/org/sahli/asciidoc/confluence/publisher/docker/DockerBasedPublishingIntegrationTest.java
@@ -162,6 +162,21 @@ public class DockerBasedPublishingIntegrationTest {
     }
 
     @Test
+    public void publish_withMaxRequestsPerSecond() {
+        // arrange
+        Map<String, String> env = mandatoryEnvVars();
+        env.put("MAX_REQUESTS_PER_SECOND", "1");
+
+        // act
+        publishAndVerify("default", env, () -> {
+            // assert
+            givenAuthenticatedAsPublisher()
+                    .when().get(childPages())
+                    .then().body("results.title", hasItem("Index"));
+        });
+    }
+
+    @Test
     public void publish_withProxySchemeHostAndPort_allowsPublishingViaProxy() {
         // arrange
         withForwardProxyEnabled("proxy", 8443, () -> {

--- a/asciidoc-confluence-publisher-maven-plugin/src/it/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojoIntegrationTest.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/it/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojoIntegrationTest.java
@@ -173,6 +173,21 @@ public class AsciidocConfluencePublisherMojoIntegrationTest {
     }
 
     @Test
+    public void publish_withMaxRequestsPerSecond() throws Exception {
+            // arrange
+        Map<String, String> properties = mandatoryProperties();
+        properties.put("maxRequestsPerSecond", "1");
+
+        // act
+        publishAndVerify("default", properties, () -> {
+            // assert
+            givenAuthenticatedAsPublisher()
+                    .when().get(childPages())
+                    .then().body("results.title", hasItem("Index"));
+        });
+    }
+
+    @Test
     public void publish_withProxySchemeHostAndPort_allowsPublishingViaProxy() throws Exception {
         // arrange
         withForwardProxyEnabled("localhost", 8443, (proxyPort) -> {

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -64,6 +64,9 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
     @Parameter(property = PREFIX + "skipSslVerification", defaultValue = "false")
     private boolean skipSslVerification;
 
+    @Parameter(property = PREFIX + "maxRequestsPerSecond")
+    private Integer maxRequestsPerSecond;
+
     @Parameter(property = PREFIX + "spaceKey", required = true)
     private String spaceKey;
 
@@ -127,6 +130,8 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
 
             ProxyConfiguration proxyConfiguration = new ProxyConfiguration(this.proxyScheme, this.proxyHost, this.proxyPort, this.proxyUsername, this.proxyPassword);
             ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(this.rootConfluenceUrl, proxyConfiguration, this.skipSslVerification, this.username, this.password);
+            confluenceRestClient.setMaxRequestsPerSecond(this.maxRequestsPerSecond);
+
             ConfluencePublisherListener confluencePublisherListener = new LoggingConfluencePublisherListener(getLog());
 
             ConfluencePublisher confluencePublisher = new ConfluencePublisher(confluencePublisherMetadata, this.publishingStrategy, confluenceRestClient, confluencePublisherListener, this.versionMessage);


### PR DESCRIPTION
Currently the Confluence Publisher assumes that Confluence is
configured to accept unlimited HTTP requests. Unfortunately there are
two complications:

Confluence Data Center allows administrators to limit the
number of REST api calls per second
For on-premise instances, solutions such as NGINX can be configured
to reduce stress on Confluence.
This change will extend the CLI api with the optional setting
maxRequestsPerSecond which allows you to specify the maximum
number of HTTP calls per second.

Decided to extend the constructor(s) of ConfluenceRestClient as
all previous connection related parameters are managed as such - feel
free to suggest another approach.

The RateLimiter provided by guava is commonly used for this
purpose, light weight and is provided under the same license
(Apache 2.0). Implementation of a (custom-) solution would be, in
my opinion, adding too much risk & maintenance cost.

Tested with the extended test cases & Confluence instance with different rate limits.

Implements #258