### PR TITLE
Feature/collapseable code block

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_listing.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_listing.html.slim
@@ -8,6 +8,8 @@
       ac:parameter ac:name="linenumbers" true
     - if attr? :start
       ac:parameter ac:name="firstline" =(attr :start)
+    - if attr? :collapse
+      ac:parameter ac:name="collapse" =(attr :collapse)
     ac:plain-text-body
       <![CDATA[#{content}]]>
 - else

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
@@ -60,9 +60,19 @@ public class MyCode {
 }
 ----
 
-Collapsing of code block is supported
+Collapsing of code block is supported with `collapse` option
 
-[source,java,collapse=true]
+[listing]
+....
+[source,java,title="Some unimportant or lengthy code hidden by default",collapse=true]
+----
+public class MyCode  {
+    // long code block that should not be visible by default
+}
+----
+....
+
+[source,java,title="Some unimportant or lengthy code hidden by default",collapse=true]
 ----
 public class MyCode  {
     // long code block that should not be visible by default

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
@@ -60,6 +60,14 @@ public class MyCode {
 }
 ----
 
+Collapsing of code block is supported
+
+[source,java,collapse=true]
+----
+public class MyCode  {
+    // long code block that should not be visible by default
+}
+----
 
 == Source Blocks from External Files (Full Content)
 


### PR DESCRIPTION
Support for `collapse` attribute in code blocks. Fixes #281 

I could not find tests for individual rendering of page elements, so just udpated ruby template and docs.