### PR TITLE
Updated dependency versions

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/asciidoc-confluence-publisher-cli/pom.xml
+++ b/asciidoc-confluence-publisher-cli/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/ArgumentsParserTest.java
+++ b/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/ArgumentsParserTest.java
@@ -6,8 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class ArgumentsParserTest {

--- a/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClientTest.java
+++ b/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClientTest.java
@@ -20,9 +20,9 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.StreamSupport.stream;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class AsciidocConfluencePublisherCommandLineClientTest {

--- a/asciidoc-confluence-publisher-client/pom.xml
+++ b/asciidoc-confluence-publisher-client/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/HttpRequestFactoryTest.java
+++ b/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/HttpRequestFactoryTest.java
@@ -21,9 +21,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.function.ThrowingRunnable;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,11 +32,11 @@ import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.Assert.assertThrows;
 import static org.sahli.asciidoc.confluence.publisher.client.utils.InputStreamUtils.fileContent;
 import static org.sahli.asciidoc.confluence.publisher.client.utils.InputStreamUtils.inputStreamAsString;
 import static org.sahli.asciidoc.confluence.publisher.client.utils.SameJsonAsMatcher.isSameJsonAs;
@@ -53,9 +52,6 @@ public class HttpRequestFactoryTest {
     private static final String ROOT_CONFLUENCE_URL = "http://confluence.com";
     private static final String CONFLUENCE_REST_API_ENDPOINT = ROOT_CONFLUENCE_URL + "/rest/api";
 
-    @Rule
-    public final ExpectedException expectedException = none();
-
     private HttpRequestFactory httpRequestFactory;
 
     @Before
@@ -65,12 +61,7 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void instantiation_withEmptyConfluenceRestApiEndpoint_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("rootConfluenceUrl must be set");
-
-        // arrange + act
-        new HttpRequestFactory("");
+        checkThrowsOnMissingValue("rootConfluenceUrl", () -> new HttpRequestFactory(""));
     }
 
     @Test
@@ -119,22 +110,14 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void addPageUnderAncestorRequest_withBlankTitle_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("title must be set");
-
-        // arrange + act
-        this.httpRequestFactory.addPageUnderAncestorRequest("~personalSpace", "1234", "", "content", "version message");
+        checkThrowsOnMissingValue("title",
+                () -> this.httpRequestFactory.addPageUnderAncestorRequest("~personalSpace", "1234", "", "content", "version message"));
     }
 
     @Test
     public void addPageUnderAncestorRequest_withoutAncestorId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("ancestorId must be set");
-
-        // arrange + act
-        this.httpRequestFactory.addPageUnderAncestorRequest("~personalSpace", "", "title", "content", "version message");
+        checkThrowsOnMissingValue("ancestorId",
+                () -> this.httpRequestFactory.addPageUnderAncestorRequest("~personalSpace", "", "title", "content", "version message"));
     }
 
     @Test
@@ -144,7 +127,7 @@ public class HttpRequestFactoryTest {
         String ancestorId = "1";
         String title = "title";
         String content = "content";
-        Integer version = 2;
+        int version = 2;
         String versionMessage = "version message";
         boolean notifyWatchers = false;
 
@@ -168,7 +151,7 @@ public class HttpRequestFactoryTest {
         String ancestorId = null;
         String title = "title";
         String content = "content";
-        Integer version = 2;
+        int version = 2;
         String versionMessage = null;
         boolean notifyWatchers = true;
 
@@ -187,22 +170,14 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void updatePageRequest_withEmptyContentId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("contentId must be set");
-
-        // arrange + act
-        this.httpRequestFactory.updatePageRequest("", "1", "title", "content", 2, "test message", true);
+        checkThrowsOnMissingValue("contentId",
+                () -> this.httpRequestFactory.updatePageRequest("", "1", "title", "content", 2, "test message", true));
     }
 
     @Test
     public void updatePageRequest_withEmptyTitle_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("title must be set");
-
-        // arrange + act
-        this.httpRequestFactory.updatePageRequest("1234", "1", "", "content", 2, "test message", true);
+        checkThrowsOnMissingValue("title",
+                () -> this.httpRequestFactory.updatePageRequest("1234", "1", "", "content", 2, "test message", true));
     }
 
     @Test
@@ -220,12 +195,8 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void deletePageRequest_withEmptyContentId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("contentId must be set");
-
-        // arrange + act
-        this.httpRequestFactory.deletePageRequest("");
+        checkThrowsOnMissingValue("contentId",
+                () -> this.httpRequestFactory.deletePageRequest(""));
     }
 
     @Test
@@ -252,32 +223,20 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void addAttachmentRequest_withEmptyContentId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("contentId must be set");
-
-        // arrange + act
-        this.httpRequestFactory.addAttachmentRequest("", "file.txt", new ByteArrayInputStream("hello".getBytes()));
+        checkThrowsOnMissingValue("contentId",
+                () -> this.httpRequestFactory.addAttachmentRequest("", "file.txt", new ByteArrayInputStream("hello".getBytes())));
     }
 
     @Test
     public void addAttachmentRequest_withEmptyAttachmentFileName_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("attachmentFileName");
-
-        // arrange + act
-        this.httpRequestFactory.addAttachmentRequest("1234", "", new ByteArrayInputStream("hello".getBytes()));
+        checkThrowsOnMissingValue("attachmentFileName",
+                () -> this.httpRequestFactory.addAttachmentRequest("1234", "", new ByteArrayInputStream("hello".getBytes())));
     }
 
     @Test
     public void addAttachmentRequest_withNullAttachmentContent_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("attachmentContent");
-
-        // arrange + act
-        this.httpRequestFactory.addAttachmentRequest("1234", "file.txt", null);
+        checkThrowsOnMissingValue("attachmentContent",
+                () -> this.httpRequestFactory.addAttachmentRequest("1234", "file.txt", null));
     }
 
     @Test
@@ -328,32 +287,20 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void updateAttachmentContentRequest_withEmptyContentId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("contentId must be set");
-
-        // arrange + act
-        this.httpRequestFactory.updateAttachmentContentRequest("", "45", new ByteArrayInputStream("hello".getBytes()), true);
+        checkThrowsOnMissingValue("contentId",
+                () -> this.httpRequestFactory.updateAttachmentContentRequest("", "45", new ByteArrayInputStream("hello".getBytes()), true));
     }
 
     @Test
     public void updateAttachmentContentRequest_withEmptyAttachmentId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("attachmentId must be set");
-
-        // arrange + act
-        this.httpRequestFactory.updateAttachmentContentRequest("1234", "", new ByteArrayInputStream("hello".getBytes()), true);
+        checkThrowsOnMissingValue("attachmentId",
+                () -> this.httpRequestFactory.updateAttachmentContentRequest("1234", "", new ByteArrayInputStream("hello".getBytes()), true));
     }
 
     @Test
     public void updateAttachmentContentRequest_withNullAttachmentContent_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("attachmentContent");
-
-        // arrange + act
-        this.httpRequestFactory.updateAttachmentContentRequest("1234", "45", null, true);
+        checkThrowsOnMissingValue("attachmentContent",
+                () -> this.httpRequestFactory.updateAttachmentContentRequest("1234", "45", null, true));
     }
 
     @Test
@@ -371,12 +318,8 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void deleteAttachmentRequest_withEmptyAttachmentId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("attachmentId must be set");
-
-        // arrange + act
-        this.httpRequestFactory.deleteAttachmentRequest("");
+        checkThrowsOnMissingValue("attachmentId",
+                () -> this.httpRequestFactory.deleteAttachmentRequest(""));
     }
 
     @Test
@@ -396,22 +339,14 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void getPageByTitleRequest_withEmptySpaceKey_throwsIllegalArgumentException() {
-        // arrange
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("spaceKey must be set");
-
-        // act
-        this.httpRequestFactory.getPageByTitleRequest("", "Some page");
+        checkThrowsOnMissingValue("spaceKey",
+                () -> this.httpRequestFactory.getPageByTitleRequest("", "Some page"));
     }
 
     @Test
     public void getPageByTitleRequest_withEmptyTitle_throwsIllegalArgumentException() {
-        // arrange
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("title must be set");
-
-        // act
-        this.httpRequestFactory.getPageByTitleRequest("~personalSpace", "");
+        checkThrowsOnMissingValue("title",
+                () -> this.httpRequestFactory.getPageByTitleRequest("~personalSpace", ""));
     }
 
     @Test
@@ -444,22 +379,14 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void getAttachmentByFileNameRequest_withEmptyContentId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("contentId must be set");
-
-        // act
-        this.httpRequestFactory.getAttachmentByFileNameRequest("", "file.txt", null);
+        checkThrowsOnMissingValue("contentId",
+                () -> this.httpRequestFactory.getAttachmentByFileNameRequest("", "file.txt", null));
     }
 
     @Test
     public void getAttachmentByFileNameRequest_withEmptyAttachmentFileName_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("attachmentFileName must be set");
-
-        // act
-        this.httpRequestFactory.getAttachmentByFileNameRequest("1234", "", null);
+        checkThrowsOnMissingValue("attachmentFileName",
+                () -> this.httpRequestFactory.getAttachmentByFileNameRequest("1234", "", null));
     }
 
     @Test
@@ -488,12 +415,8 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void getChildPagesByIdRequest_withBlankParentContentId_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("parentContentId must be set");
-
-        // arrange + act
-        this.httpRequestFactory.getChildPagesByIdRequest("", null, null, null);
+        checkThrowsOnMissingValue("parentContentId",
+                () -> this.httpRequestFactory.getChildPagesByIdRequest("", null, null, null));
     }
 
     @Test
@@ -619,12 +542,14 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void getAttachmentContentRequest_withBlankRelativeDownloadLink_throwsIllegalArgumentException() {
-        // assert
-        this.expectedException.expect(IllegalArgumentException.class);
-        this.expectedException.expectMessage("relativeDownloadLink must be set");
+        checkThrowsOnMissingValue("relativeDownloadLink", () -> this.httpRequestFactory.getAttachmentContentRequest(""));
+    }
 
+    private void checkThrowsOnMissingValue(String field, ThrowingRunnable runnable) {
         // arrange + act
-        this.httpRequestFactory.getAttachmentContentRequest("");
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, runnable);
+
+        assertThat(ex.getMessage(), is(field + " must be set"));
     }
 
     @Test

--- a/asciidoc-confluence-publisher-converter/pom.xml
+++ b/asciidoc-confluence-publisher-converter/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverterTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverterTest.java
@@ -19,7 +19,6 @@ package org.sahli.asciidoc.confluence.publisher.converter;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.sahli.asciidoc.confluence.publisher.client.metadata.ConfluencePageMetadata;
 import org.sahli.asciidoc.confluence.publisher.client.metadata.ConfluencePublisherMetadata;
@@ -33,8 +32,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.exists;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.sahli.asciidoc.confluence.publisher.converter.AsciidocConfluenceConverter.uniquePageId;
 
 /**
@@ -50,9 +49,6 @@ public class AsciidocConfluenceConverterTest {
 
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Rule
-    public final ExpectedException expectedException = none();
 
     @Test
     public void convertAndBuildConfluencePages_withThreeLevelAdocStructure_convertsTemplatesAndReturnsMetadata() throws Exception {
@@ -107,13 +103,12 @@ public class AsciidocConfluenceConverterTest {
 
         AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder, UTF_8);
 
-        // assert
-        this.expectedException.expect(RuntimeException.class);
-        this.expectedException.expectMessage("Attachment 'non-existing-attachment.png' does not exist");
-
         // act
         AsciidocConfluenceConverter asciidocConfluenceConverter = new AsciidocConfluenceConverter("~personalSpace", "1234");
-        asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, buildFolder, emptyMap());
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, buildFolder, emptyMap()));
+
+        // assert
+        assertThat(ex.getMessage(), is("Attachment 'non-existing-attachment.png' does not exist"));
     }
 
     @Test

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -16,12 +16,8 @@
 
 package org.sahli.asciidoc.confluence.publisher.converter;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.sahli.asciidoc.confluence.publisher.converter.AsciidocPagesStructureProvider.AsciidocPage;
 
@@ -45,16 +41,12 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sahli.asciidoc.confluence.publisher.converter.AsciidocConfluencePage.newAsciidocConfluencePage;
-import static org.sahli.asciidoc.confluence.publisher.converter.AsciidocConfluencePageTest.RootCauseMatcher.rootCauseWithMessage;
 
 /**
  * @author Alain Sahli
@@ -69,9 +61,6 @@ public class AsciidocConfluencePageTest {
 
     @ClassRule
     public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-
-    @Rule
-    public final ExpectedException expectedException = none();
 
     @Test
     public void render_asciidocWithTopLevelHeader_returnsConfluencePageWithPageTitleFromTopLevelHeader() {
@@ -217,13 +206,13 @@ public class AsciidocConfluencePageTest {
         // arrange
         String adoc = "Content";
 
-        // assert
-        this.expectedException.expect(RuntimeException.class);
-        this.expectedException.expectMessage("failed to create confluence page for asciidoc content in");
-        this.expectedException.expect(rootCauseWithMessage("top-level heading or title meta information must be set"));
-
         // act
-        newAsciidocConfluencePage(asciidocPage(adoc), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> newAsciidocConfluencePage(asciidocPage(adoc), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath()));
+
+        // assert
+        assertThat(ex.getMessage(), startsWith("failed to create confluence page for asciidoc content in"));
+        assertThat(ex.getCause().getMessage(), is("top-level heading or title meta information must be set"));
     }
 
     @Test
@@ -1818,31 +1807,6 @@ public class AsciidocConfluencePageTest {
         } catch (Exception e) {
             throw new RuntimeException("Could not set default charset", e);
         }
-    }
-
-
-    static class RootCauseMatcher extends TypeSafeMatcher<Exception> {
-
-        private final String message;
-
-        private RootCauseMatcher(String message) {
-            this.message = message;
-        }
-
-        @Override
-        protected boolean matchesSafely(Exception exception) {
-            return exception.getCause().getMessage().equals(this.message);
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("root cause with message '" + this.message + "'");
-        }
-
-        static RootCauseMatcher rootCauseWithMessage(String message) {
-            return new RootCauseMatcher(message);
-        }
-
     }
 
 }

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/FolderBasedAsciidocPagesStructureProviderTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/FolderBasedAsciidocPagesStructureProviderTest.java
@@ -20,21 +20,20 @@ import org.junit.Test;
 import org.sahli.asciidoc.confluence.publisher.converter.AsciidocPagesStructureProvider.AsciidocPage;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class FolderBasedAsciidocPagesStructureProviderTest {
 
-    private static AsciidocPage NON_EXISTING_ASCIIDOC_PAGE = mock(AsciidocPage.class);
+    private final static AsciidocPage NON_EXISTING_ASCIIDOC_PAGE = mock(AsciidocPage.class);
 
     @Test
     public void structure_nestedStructure_returnsAsciidocPagesStructureWithAllNonIncludeAdocFiles() {

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/NoOpPageTitlePostProcessorTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/NoOpPageTitlePostProcessorTest.java
@@ -18,8 +18,8 @@ package org.sahli.asciidoc.confluence.publisher.converter;
 
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Christian Stettler

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/PrefixAndSuffixPageTitlePostProcessorTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/PrefixAndSuffixPageTitlePostProcessorTest.java
@@ -18,8 +18,8 @@ package org.sahli.asciidoc.confluence.publisher.converter;
 
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Christian Stettler

--- a/asciidoc-confluence-publisher-docker/pom.xml
+++ b/asciidoc-confluence-publisher-docker/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/asciidoc-confluence-publisher-maven-plugin/pom.xml
+++ b/asciidoc-confluence-publisher-maven-plugin/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.1</version>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -170,13 +170,13 @@
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj</artifactId>
-                <version>2.4.2</version>
+                <version>2.4.3</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj-diagram</artifactId>
-                <version>2.0.5</version>
+                <version>2.1.0</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <httpcomponents.version>4.5.10</httpcomponents.version>
+        <httpcomponents.version>4.5.13</httpcomponents.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -104,13 +104,13 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.10.0.pr1</version>
+                <version>2.10.5</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.9</version>
+                <version>1.15</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
@@ -122,13 +122,13 @@
             <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>json-path</artifactId>
-                <version>3.0.2</version>
+                <version>4.3.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
-                <version>3.0.2</version>
+                <version>4.3.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -170,31 +170,31 @@
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.2</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj-diagram</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.5</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.10.19</version>
+                <version>3.6.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.25</version>
+                <version>1.7.30</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -206,7 +206,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
-                <version>1.12.0</version>
+                <version>1.15.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -224,7 +224,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.22.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -234,17 +234,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.22.2</version>
                 </plugin>
                 <plugin>
                     <groupId>com.spotify</groupId>
                     <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>1.4.0</version>
+                    <version>1.4.13</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.12</version>
+                    <version>3.2.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -294,7 +294,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -307,7 +307,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -320,7 +320,7 @@
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>4.3.0</version>
                 <configuration>
                     <repoToken>dubhyzNPv8kQb8DQrTM5Iiv7Mgyq4azFX</repoToken>
                 </configuration>
@@ -328,7 +328,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.5.201505241946</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
1. dependencies version bumped to up to date values
2. update plugin versions to up to date values. This will help to
  - use jdk11 to compile project (jacoco)
  - start using junit5 later (surefire and failsafe plugin versions)
3. Removed all deprecations that are present due to migration to junit 4.13