### PR TITLE
Support configuring underlying HTTP client using system properties

### DIFF
--- a/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
+++ b/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
@@ -93,7 +93,7 @@ public class AsciidocConfluencePublisherCommandLineClient {
             } else {
                 ProxyConfiguration proxyConfiguration = new ProxyConfiguration(proxyScheme, proxyHost, proxyPort, proxyUsername, proxyPassword);
 
-                ConfluenceRestClient confluenceClient = new ConfluenceRestClient(rootConfluenceUrl, proxyConfiguration, skipSslVerification, maxRequestsPerSecond, username, password);
+                ConfluenceRestClient confluenceClient = new ConfluenceRestClient(rootConfluenceUrl, proxyConfiguration, skipSslVerification, false, maxRequestsPerSecond, username, password);
                 ConfluencePublisher confluencePublisher = new ConfluencePublisher(confluencePublisherMetadata, publishingStrategy, orphanRemovalStrategy, confluenceClient, new SystemOutLoggingConfluencePublisherListener(), versionMessage, notifyWatchers);
                 confluencePublisher.publish();
             }

--- a/asciidoc-confluence-publisher-client/src/it/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisherIntegrationTest.java
+++ b/asciidoc-confluence-publisher-client/src/it/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisherIntegrationTest.java
@@ -304,7 +304,7 @@ public class ConfluencePublisherIntegrationTest {
     }
 
     private static ConfluenceRestClient confluenceRestClient() {
-        return new ConfluenceRestClient("http://localhost:8090", false, null, "confluence-publisher-it", "1234");
+        return new ConfluenceRestClient("http://localhost:8090", false, false, null, "confluence-publisher-it", "1234");
     }
 
 }

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClient.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClient.java
@@ -66,12 +66,12 @@ public class ConfluenceRestClient implements ConfluenceClient {
     private final HttpRequestFactory httpRequestFactory;
     private final RateLimiter rateLimiter;
 
-    public ConfluenceRestClient(String rootConfluenceUrl, boolean disableSslVerification, Double maxRequestsPerSecond, String username, String password) {
-        this(rootConfluenceUrl, null, disableSslVerification, maxRequestsPerSecond, username, password);
+    public ConfluenceRestClient(String rootConfluenceUrl, boolean disableSslVerification, boolean enableHttpClientSystemProperties, Double maxRequestsPerSecond, String username, String password) {
+        this(rootConfluenceUrl, null, disableSslVerification, enableHttpClientSystemProperties, maxRequestsPerSecond, username, password);
     }
 
-    public ConfluenceRestClient(String rootConfluenceUrl, ProxyConfiguration proxyConfiguration, boolean disableSslVerification, Double maxRequestsPerSecond, String username, String password) {
-        this(rootConfluenceUrl, defaultHttpClient(proxyConfiguration, disableSslVerification), maxRequestsPerSecond, username, password);
+    public ConfluenceRestClient(String rootConfluenceUrl, ProxyConfiguration proxyConfiguration, boolean disableSslVerification, boolean enableHttpClientSystemProperties, Double maxRequestsPerSecond, String username, String password) {
+        this(rootConfluenceUrl, defaultHttpClient(proxyConfiguration, disableSslVerification, enableHttpClientSystemProperties), maxRequestsPerSecond, username, password);
     }
 
     public ConfluenceRestClient(String rootConfluenceUrl, CloseableHttpClient httpClient, Double maxRequestsPerSecond, String username, String password) {
@@ -390,7 +390,7 @@ public class ConfluenceRestClient implements ConfluenceClient {
         }
     }
 
-    private static CloseableHttpClient defaultHttpClient(ProxyConfiguration proxyConfiguration, boolean disableSslVerification) {
+    private static CloseableHttpClient defaultHttpClient(ProxyConfiguration proxyConfiguration, boolean disableSslVerification, boolean enableHttpClientSystemProperties) {
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectionRequestTimeout(20 * 1000)
                 .setConnectTimeout(20 * 1000)
@@ -399,6 +399,10 @@ public class ConfluenceRestClient implements ConfluenceClient {
 
         HttpClientBuilder builder = HttpClients.custom()
                 .setDefaultRequestConfig(requestConfig);
+
+        if (enableHttpClientSystemProperties) {
+            builder.useSystemProperties();
+        }
 
         if (proxyConfiguration != null) {
             if (proxyConfiguration.proxyHost() != null) {

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -144,6 +144,16 @@ When relying on Maven support for encrypted credentials using the `serverId` con
   signed certificates.
 | optional (defaults to `false`)
 
+| enableHttpClientSystemProperties
+| Defines whether to enable support for configuring the underlying HTTP client using system properties passed to Maven.
+  Useful for configuring custom keys and trust stores for SSL.
+  +
+  +
+  _Note:_ see https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html[HTTP client documentation]
+  for supported system properties. Also, mixing `skipSslVerification` or the `proxy`-related configuration options with
+  `enableHttpClientSystemProperties` is currently not supported.
+| optional (defaults to `false`, only supported for Maven plugin)
+
 | maxRequestsPerSecond
 | Defines the number (positive integer or double) of REST API calls to execute within a second.
 | optional (defaults to no rate limit)

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -71,6 +71,9 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
     @Parameter(property = PREFIX + "skipSslVerification", defaultValue = "false")
     private boolean skipSslVerification;
 
+    @Parameter(property = PREFIX + "enableHttpClientSystemProperties", defaultValue = "false")
+    private boolean enableHttpClientSystemProperties;
+
     @Parameter(property = PREFIX + "maxRequestsPerSecond")
     private Double maxRequestsPerSecond;
 
@@ -161,7 +164,7 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
                 getLog().info("Publishing to Confluence skipped ('convert only' is enabled)");
             } else {
                 ProxyConfiguration proxyConfiguration = new ProxyConfiguration(this.proxyScheme, this.proxyHost, this.proxyPort, this.proxyUsername, this.proxyPassword);
-                ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(this.rootConfluenceUrl, proxyConfiguration, this.skipSslVerification, this.maxRequestsPerSecond, this.username, this.password);
+                ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(this.rootConfluenceUrl, proxyConfiguration, this.skipSslVerification, this.enableHttpClientSystemProperties, this.maxRequestsPerSecond, this.username, this.password);
                 ConfluencePublisherListener confluencePublisherListener = new LoggingConfluencePublisherListener(getLog());
 
                 ConfluencePublisher confluencePublisher = new ConfluencePublisher(confluencePublisherMetadata, this.publishingStrategy, this.orphanRemovalStrategy, confluenceRestClient, confluencePublisherListener, this.versionMessage, this.notifyWatchers);


### PR DESCRIPTION
Use `enableHttpClientSystemProperties` to enable support for configuring the underlying HTTP client using system properties and use the corresponding system properties documented on https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html

Fixes #302 