### PR TITLE
Issue 317: Allow use of a Personal Access token for on-premise servers

### DIFF
--- a/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClientTest.java
+++ b/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClientTest.java
@@ -399,6 +399,26 @@ public class ConfluenceRestClientTest {
     }
 
     @Test
+    public void sendRequest_withProvidedPasswordButNoUsername_setsCredentialsProvider() throws Exception {
+        // arrange
+        CloseableHttpClient closeableHttpClient = anyCloseableHttpClient();
+        ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient("http://confluence.com", closeableHttpClient, null, "", "personalAccessToken");
+        HttpGet httpRequest = new HttpGet("http://confluence.com");
+        ArgumentCaptor<HttpRequestBase> httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpRequestBase.class);
+
+        // act
+        confluenceRestClient.sendRequest(httpRequest, (response) -> null);
+
+        // assert
+        verify(closeableHttpClient, times(1)).execute(httpRequestArgumentCaptor.capture());
+        HttpRequestBase httpRequestBase = httpRequestArgumentCaptor.getValue();
+
+        assertThat(httpRequestBase, is(httpRequest));
+        assertThat(httpRequestBase.getHeaders("Authorization").length, is(1));
+        assertThat(httpRequestBase.getFirstHeader("Authorization").getValue(), is("Bearer personalAccessToken"));
+    }
+
+    @Test
     public void sendRequest_withRateLimitEnabled_blocksBeforeSendingSecondRequest() {
         // arrange
         CloseableHttpClient closeableHttpClient = anyCloseableHttpClient();

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -184,6 +184,9 @@ When relying on Maven support for encrypted credentials using the `serverId` con
   be used as password.
   +
   +
+  _Note:_ when publishing to on-premise Confluence with an API token, leave the username empty ("").
+  +
+  +
   _Note:_ Overrules password defined by serverId, when set in conjunction with serverId
 | mandatory, if serverId is not specified
 


### PR DESCRIPTION
Possible implementation of issue #317.

Changes:
* Renamed the `password` variable in the rest client to `passwordOrPersonalAccessToken` to denote its dual use
   (as also indicated by existing documentation)
* Added the ability to use `Bearer` authentication in addition to `Basic` authentication
* Added test case
* Adjusted documentation

As this is my first PR here, any comments to improve are welcome.