### PR TITLE
Added support for C4-PlantUML diagrams.

### DIFF
--- a/asciidoc-confluence-publisher-converter/pom.xml
+++ b/asciidoc-confluence-publisher-converter/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>net.sourceforge.plantuml</groupId>
             <artifactId>plantuml</artifactId>
-            <version>1.2021.9</version>
+            <version>1.2021.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/asciidoc-confluence-publisher-converter/pom.xml
+++ b/asciidoc-confluence-publisher-converter/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>net.sourceforge.plantuml</groupId>
             <artifactId>plantuml</artifactId>
-            <version>1.2019.6</version>
+            <version>1.2021.9</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1236,7 +1236,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
-        String expectedContent = "<ac:image ac:height=\"174\" ac:width=\"56\"><ri:attachment ri:filename=\"embedded-diagram.png\"></ri:attachment></ac:image>";
+        String expectedContent = "<ac:image ac:height=\"176\" ac:width=\"60\"><ri:attachment ri:filename=\"embedded-diagram.png\"></ri:attachment></ac:image>";
         assertThat(asciidocConfluencePage.content(), containsString(expectedContent));
         assertThat(exists(assetsTargetFolderFor(asciidocPage).resolve("embedded-diagram.png")), is(true));
     }
@@ -1251,7 +1251,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
-        String expectedContent = "<ac:image ac:height=\"174\" ac:width=\"56\"><ri:attachment ri:filename=\"included-diagram.png\"></ri:attachment></ac:image>";
+        String expectedContent = "<ac:image ac:height=\"176\" ac:width=\"60\"><ri:attachment ri:filename=\"included-diagram.png\"></ri:attachment></ac:image>";
         assertThat(asciidocConfluencePage.content(), containsString(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -29,6 +29,7 @@ Currently, the Confluence Publisher supports the following AsciiDoc features:
 * <<00-index/10-plantuml.adoc#, PlantUML>>
 * <<00-index/11-attachments.adoc#, Attachments>>
 * <<00-index/12-table-of-contents.adoc#, Table of Contents>>
+* <<00-index/13-additional-features.adoc#, Additional Features>>
 
 The Confluence Publisher uses AsciidoctorJ and therefore supports documentation written using the Asciidoctor syntax.
 See link:http://asciidoctor.org/docs/user-manual/[Asciidoctor User Manual] for more information about Asciidoctor.

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/10-plantuml.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/10-plantuml.adoc
@@ -51,46 +51,24 @@ https://github.com/plantuml-stdlib/C4-PlantUML[C4-PlantUML] diagrams are support
 ----
 [plantuml, c4-diagram, svg]
 ....
-!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
-' uncomment the following line and comment the first to use locally
-' !include C4_Context.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
-LAYOUT_WITH_LEGEND()
+Person(personAlias, "Label", "Optional Description")
+Container(containerAlias, "Label", "Technology", "Optional Description")
+System(systemAlias, "Label", "Optional Description")
 
-title System Context diagram for Internet Banking System
-
-Person(customer, "Personal Banking Customer", "A customer of the bank, with personal bank accounts.")
-System(banking_system, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")
-
-System_Ext(mail_system, "E-mail system", "The internal Microsoft Exchange e-mail system.")
-System_Ext(mainframe, "Mainframe Banking System", "Stores all of the core banking information about customers, accounts, transactions, etc.")
-
-Rel(customer, banking_system, "Uses")
-Rel_Back(customer, mail_system, "Sends e-mails to")
-Rel_Neighbor(banking_system, mail_system, "Sends e-mails", "SMTP")
-Rel(banking_system, mainframe, "Uses")
+Rel(personAlias, containerAlias, "Label", "Optional Technology")
 ....
 ----
 
 
 [plantuml, c4-diagram, svg]
 ....
-!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
-' uncomment the following line and comment the first to use locally
-' !include C4_Context.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
-LAYOUT_WITH_LEGEND()
+Person(personAlias, "Label", "Optional Description")
+Container(containerAlias, "Label", "Technology", "Optional Description")
+System(systemAlias, "Label", "Optional Description")
 
-title System Context diagram for Internet Banking System
-
-Person(customer, "Personal Banking Customer", "A customer of the bank, with personal bank accounts.")
-System(banking_system, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")
-
-System_Ext(mail_system, "E-mail system", "The internal Microsoft Exchange e-mail system.")
-System_Ext(mainframe, "Mainframe Banking System", "Stores all of the core banking information about customers, accounts, transactions, etc.")
-
-Rel(customer, banking_system, "Uses")
-Rel_Back(customer, mail_system, "Sends e-mails to")
-Rel_Neighbor(banking_system, mail_system, "Sends e-mails", "SMTP")
-Rel(banking_system, mainframe, "Uses")
+Rel(personAlias, containerAlias, "Label", "Optional Technology")
 ....

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/10-plantuml.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/10-plantuml.adoc
@@ -49,7 +49,7 @@ plantuml::../files/included-diagram.puml[]
 https://github.com/plantuml-stdlib/C4-PlantUML[C4-PlantUML] diagrams are supported as well.
 
 ----
-[plantuml, c4-diagram, svg]
+[plantuml, c4-diagram, png]
 ....
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
@@ -62,7 +62,7 @@ Rel(personAlias, containerAlias, "Label", "Optional Technology")
 ----
 
 
-[plantuml, c4-diagram, svg]
+[plantuml, c4-diagram, png]
 ....
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/10-plantuml.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/10-plantuml.adoc
@@ -43,3 +43,54 @@ plantuml::../files/included-diagram.puml[]
 ....
 
 plantuml::../files/included-diagram.puml[]
+
+== C4-PlantUML
+
+https://github.com/plantuml-stdlib/C4-PlantUML[C4-PlantUML] diagrams are supported as well.
+
+----
+[plantuml, c4-diagram, svg]
+....
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
+' uncomment the following line and comment the first to use locally
+' !include C4_Context.puml
+
+LAYOUT_WITH_LEGEND()
+
+title System Context diagram for Internet Banking System
+
+Person(customer, "Personal Banking Customer", "A customer of the bank, with personal bank accounts.")
+System(banking_system, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")
+
+System_Ext(mail_system, "E-mail system", "The internal Microsoft Exchange e-mail system.")
+System_Ext(mainframe, "Mainframe Banking System", "Stores all of the core banking information about customers, accounts, transactions, etc.")
+
+Rel(customer, banking_system, "Uses")
+Rel_Back(customer, mail_system, "Sends e-mails to")
+Rel_Neighbor(banking_system, mail_system, "Sends e-mails", "SMTP")
+Rel(banking_system, mainframe, "Uses")
+....
+----
+
+
+[plantuml, c4-diagram, svg]
+....
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
+' uncomment the following line and comment the first to use locally
+' !include C4_Context.puml
+
+LAYOUT_WITH_LEGEND()
+
+title System Context diagram for Internet Banking System
+
+Person(customer, "Personal Banking Customer", "A customer of the bank, with personal bank accounts.")
+System(banking_system, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")
+
+System_Ext(mail_system, "E-mail system", "The internal Microsoft Exchange e-mail system.")
+System_Ext(mainframe, "Mainframe Banking System", "Stores all of the core banking information about customers, accounts, transactions, etc.")
+
+Rel(customer, banking_system, "Uses")
+Rel_Back(customer, mail_system, "Sends e-mails to")
+Rel_Neighbor(banking_system, mail_system, "Sends e-mails", "SMTP")
+Rel(banking_system, mainframe, "Uses")
+....

--- a/pom.xml
+++ b/pom.xml
@@ -170,13 +170,13 @@
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.1</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj-diagram</artifactId>
-                <version>2.0.2</version>
+                <version>2.1.2</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
The following changes were made to support C4-PlantUML:

- Updated AsciidoctorJ to 2.5.1 from 2.4.0
- Updated AsciidoctorJ-Diagram to 2.1.2 from 2.0.2
- Updated PlantUML to 1.2021.2 from 1.2019.6
- Added a C4-PlantUML diagram to file 10-plantuml.adoc
- Updated two test cases to use the image dimensions generated by the updated version of PlantUML.

Resolves #310 