### PR TITLE
C4-PlantUML diagrams now support dynamic legend colors.

### DIFF
--- a/asciidoc-confluence-publisher-converter/pom.xml
+++ b/asciidoc-confluence-publisher-converter/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>net.sourceforge.plantuml</groupId>
             <artifactId>plantuml</artifactId>
-            <version>1.2021.2</version>
+            <version>1.2021.8</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj-diagram</artifactId>
-                <version>2.1.2</version>
+                <version>2.2.0</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Log message ("dynamic undefined legend colors" requires PlantUML version >= 1.2021.6, therefore only static assigned colors are used) is displayed using the AsciidoctorJ-Diagram v2.1.2. Upgrade AsciidoctorJ-Diagram and PlantUML to resolve this issue.

![image](https://user-images.githubusercontent.com/13682850/130133214-bdd47927-18c0-41e4-b76d-e06600da2758.png)
