### PR TITLE
Setup Confluence server for maven-plugin integration tests

### DIFF
--- a/asciidoc-confluence-publisher-maven-plugin/src/it/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/testutils/ConfluenceServer.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/it/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/testutils/ConfluenceServer.java
@@ -1,0 +1,10 @@
+package org.sahli.asciidoc.confluence.publisher.maven.plugin.testutils;
+
+public class ConfluenceServer {
+
+    public final int port;
+
+    public ConfluenceServer(int port) {
+        this.port = port;
+    }
+}

--- a/asciidoc-confluence-publisher-maven-plugin/src/it/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/testutils/ConfluenceServerSetup.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/it/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/testutils/ConfluenceServerSetup.java
@@ -1,0 +1,35 @@
+package org.sahli.asciidoc.confluence.publisher.maven.plugin.testutils;
+
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import java.time.Duration;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+public class ConfluenceServerSetup {
+
+    private static final int PORT = 8090;
+
+    public static ConfluenceServer setupContainer() {
+        GenericContainer genericContainer = new GenericContainer("confluencepublisher/confluence-publisher-it:6.0.5")
+                .withExposedPorts(PORT)
+                .withReuse(true)
+                .waitingFor(
+                        new LogMessageWaitStrategy()
+                                .withRegEx(".*(org.apache.catalina.startup.Catalina.start Server startup in).*\n")
+                                .withStartupTimeout(Duration.of(120, SECONDS))
+                );
+        genericContainer.start();
+        Integer confluencePort = getConfluencePort(genericContainer);
+        return new ConfluenceServer(confluencePort);
+    }
+
+    private static Integer getConfluencePort(GenericContainer container) {
+        Integer mappedPort = container.getMappedPort(PORT);
+        Testcontainers.exposeHostPorts(mappedPort);
+        return mappedPort;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
-                <version>1.12.0</version>
+                <version>1.16.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
This gives an ability to run maven-plugin integration tests without manually spinning Confluence server.