### PR TITLE
Updated the plexus-sec-dispatcher dependency

### DIFF
--- a/asciidoc-confluence-publisher-maven-plugin/pom.xml
+++ b/asciidoc-confluence-publisher-maven-plugin/pom.xml
@@ -63,7 +63,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.plexus</groupId>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-sec-dispatcher</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -198,9 +198,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.sonatype.plexus</groupId>
+                <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-sec-dispatcher</artifactId>
-                <version>1.4</version>
+                <version>2.0</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Issue #352 
Updated the "plexus-sec-dispatcher" dependency (not been maintained since May 2011) for the asciidoc-confluence-publisher-maven-plugin to avoid vulnerabilities