### PR TITLE
#365 Upgrade to JDK 11

### DIFF
--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.11-jre-slim-buster
+FROM openjdk:11.0.15-jre-slim-bullseye
 
 RUN apt-get update && \
   apt-get install -y graphviz fonts-dejavu && \

--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.15-jdk
+FROM openjdk:11-jre-slim-bullseye
 
 RUN apt-get update && \
   apt-get install -y graphviz fonts-dejavu && \

--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.15-jre-slim-bullseye
+FROM openjdk:17.0.2-slim-bullseye
 
 RUN apt-get update && \
   apt-get install -y graphviz fonts-dejavu && \

--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:openjdk:11.0.15-jre
+FROM openjdk:11.0.15-jre
 
 RUN apk add --update graphviz ttf-dejavu
 

--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim-bullseye
+FROM openjdk:11.0.11-jre-slim-buster
 
 RUN apt-get update && \
   apt-get install -y graphviz fonts-dejavu && \

--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:11.0.15-jre
+FROM openjdk:11.0.15-jdk
 
-RUN apk add --update graphviz ttf-dejavu
+RUN apt-get update && \
+  apt-get install -y graphviz fonts-dejavu && \
+  apt-get clean
 
 ADD target/asciidoc-confluence-publisher-docker-*-jar-with-dependencies.jar /opt/asciidoc-confluence-publisher-docker.jar
 ADD ./publish.sh /usr/local/bin

--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:openjdk:11.0.15-jre
 
 RUN apk add --update graphviz ttf-dejavu
 


### PR DESCRIPTION
Mostly because of security concerns, but also to reduce image size and improve performance, use a more up-to-date JDK version. Let’s just upgrade and see what the test results will be.