### PR TITLE
#365 Upgrade base image to JRE 17

### DIFF
--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.15-jre-slim-bullseye
+FROM openjdk:17.0.2-slim-bullseye
 
 RUN apt-get update && \
   apt-get install -y graphviz fonts-dejavu && \


### PR DESCRIPTION
#365 In the first place for security concerns, but also to diminish the total image size and get some free performance improvements, upgrade to JRE 17 base image.