### PR TITLE
Allow for empty username (unset) in Maven plugin

### DIFF
--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -185,17 +185,18 @@ When relying on Maven support for encrypted credentials using the `serverId` con
   +
   +
   _Note:_ Overrules username defined by serverId, when set in conjunction with serverId
-| mandatory, if serverId is not specified
+| optional (unspecified behaves like an empty string, see password)
 
 | password
-| The password of the user to use for publishing.
+| The password of the user to use for publishing or a personal access token when the username is empty or unspecified.
   +
   +
   _Note:_ when publishing to Confluence Cloud, an API token generated via the corresponding Atlassian account has to
   be used as password.
   +
   +
-  _Note:_ when publishing to on-premise Confluence with an API token, leave the username empty ("").
+  _Note:_ when publishing to on-premise Confluence with an API token, leave the username empty ("") or unspecified
+  (for Maven plugin)
   +
   +
   _Note:_ Overrules password defined by serverId, when set in conjunction with serverId

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -156,7 +156,7 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
             Map<String, Object> attributes = this.attributes != null ? this.attributes : emptyMap();
             ConfluencePublisherMetadata confluencePublisherMetadata = asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, pageTitlePostProcessor, this.confluencePublisherBuildFolder.toPath(), attributes);
 
-            if ((this.username == null) || (this.password == null)) {
+            if ((this.password == null)) {
                 applyUsernameAndPasswordFromSettings();
             }
 


### PR DESCRIPTION
This is for Issue #370 

Confluence-publisher already supports using an access token with specifying an empty password. 

This just did not work for the maven plugin, as the XML DOM will not set username to an empty string when specifying \<username>\</username> but will set username to null. 

This PR removes the requirement for the username to be non-null as the implementation of the token handling already treats an empty username and a null username identically.

With this change users can now just leave out the username in the maven pom.xml and specify a token in the password.

I also reworded the documentation to try to make things clear.  