### PR TITLE
Upgrade asciidoctorj Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,13 +170,13 @@
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj</artifactId>
-                <version>2.5.1</version>
+                <version>2.5.7</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj-diagram</artifactId>
-                <version>2.2.1</version>
+                <version>2.2.3</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Both most relevant asciidoctorj dependencies are not up to date.
This PR upgrades the following dependencies

- Upgrade to asciidoctorj 2.5.7
- Upgrade to asciidoctorj-diagram 2.2.3

