### PR TITLE
If Asciidocj logs warnings, fail the Maven build

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
@@ -17,6 +17,9 @@
 package org.sahli.asciidoc.confluence.publisher.converter;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.log.LogHandler;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
 import org.asciidoctor.Attributes;
 import org.asciidoctor.Options;
 import org.asciidoctor.ast.Document;
@@ -76,6 +79,14 @@ public class AsciidocConfluencePage {
 
     static {
         ASCIIDOCTOR.requireLibrary("asciidoctor-diagram");
+        ASCIIDOCTOR.registerLogHandler(new LogHandler() {
+            @Override
+            public void log(LogRecord logRecord) {
+                if (logRecord.getSeverity().compareTo(Severity.WARN) >= 0) {
+                    throw new RuntimeException(logRecord.getMessage());
+                }
+            }
+        });
     }
 
     private final String pageTitle;

--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
@@ -82,7 +82,7 @@ public class AsciidocConfluencePage {
         ASCIIDOCTOR.registerLogHandler(new LogHandler() {
             @Override
             public void log(LogRecord logRecord) {
-                if (logRecord.getSeverity().compareTo(Severity.WARN) >= 0) {
+                if (logRecord.getSeverity().compareTo(Severity.ERROR) >= 0) {
                     throw new RuntimeException(logRecord.getMessage());
                 }
             }

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1789,6 +1789,22 @@ public class AsciidocConfluencePageTest {
         assertThat(asciidocConfluencePage.keywords(), hasItem("bar"));
     }
 
+    @Test
+    public void unterminated_literalBlock_throwsRuntimeException() {
+        // arrange
+        String adoc = "= Page Title\n\n"
+                + "....\n"
+                + "foo\n";
+        AsciidocPage asciidocPage = asciidocPage(adoc);
+
+        // assert
+        this.expectedException.expect(RuntimeException.class);
+        this.expectedException.expectMessage("failed to create confluence page for asciidoc content in");
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+    }
+
     private static String prependTitle(String content) {
         if (!content.startsWith("= ")) {
             content = "= Default Page Title\n\n" + content;

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1790,19 +1790,23 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
-    public void unterminated_literalBlock_throwsRuntimeException() {
+    public void renderConfluencePage_asciiDocErrorLogWhileRendering_throwsRuntimeException() {
         // arrange
-        String adoc = "= Page Title\n\n"
-                + "....\n"
-                + "foo\n";
-        AsciidocPage asciidocPage = asciidocPage(adoc);
+        String adocRelyingOnMissingSequenceDiagramBinary = "" +
+                "[seqdiag#ex-seq-diag,ex-seq-diag,svg]\n" +
+                "....\n" +
+                "seqdiag {\n" +
+                "  webserver -> processor;\n" +
+                "}\n" +
+                "....\n";
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocRelyingOnMissingSequenceDiagramBinary));
 
         // assert
         this.expectedException.expect(RuntimeException.class);
         this.expectedException.expectMessage("failed to create confluence page for asciidoc content in");
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
     }
 
     private static String prependTitle(String content) {


### PR DESCRIPTION
Fixes #396.

I chose to fail on warnings already instead of errors because failing early is good. However, this is of course very subjective and I am open to change this to fail on errors. Maybe we can even make this configurable with a maven property. e.g:

```xml
<configuration>
    <failOn>WARN/ERROR</failOn>
</configuration>
```

I may need some help for this, though.