### PR TITLE
#270 Fix cross page links with anchors are rendered incorrectly 

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/helpers.rb
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/helpers.rb
@@ -193,13 +193,18 @@ module Slim::Helpers
 
   # checks if xref is referring to adoc (internal cross references not yet supported)
   def cross_page_xref? str
-    str.end_with? ".html"
+    str.include? ".html"
+  end
+
+  # checks if xref is referring to an anchor on another adoc
+  def cross_page_anchor_xref? str
+    (str.include? ".html") && (str.include? "#")
   end
 
   # removes leading hash from anchor targets
   def anchor_name str
-    if str.start_with? "#"
-      str[1..str.length]
+    if str.include? "#"
+      str[(str.index('#')+1)..str.length]
     else
       str
     end

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_anchor.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_anchor.html.slim
@@ -1,6 +1,11 @@
 - case type
 - when :xref
-  - if cross_page_xref? target
+  - if cross_page_anchor_xref? target
+    ac:link ac:anchor=(anchor_name target || id)
+      ri:page ri:content-title=target
+      ac:plain-text-link-body
+        <![CDATA[#{(xref_text || %([#{attr :refid}]))}]]>
+  - elsif cross_page_xref? target
     ac:link
       ri:page ri:content-title=target
       ac:plain-text-link-body

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1072,6 +1072,22 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithInterDocumentCrossReferenceAnchor_returnsConfluencePageWithLinkToReferencedPageByPageTitleWithAnchor() {
+        // arrange
+        Path rootFolder = copyAsciidocSourceToTemporaryFolder("src/test/resources/inter-document-cross-references");
+        AsciidocPage asciidocPage = asciidocPage(rootFolder, "source-page-reference-with-anchor.adoc");
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage), "TEST");
+
+        // assert
+        String expectedContent = "<p>This is a <ac:link ac:anchor=\"_anchor\"><ri:page ri:content-title=\"Target Page\" ri:space-key=\"TEST\"></ri:page>" +
+                "<ac:plain-text-link-body><![CDATA[reference with anchor]]></ac:plain-text-link-body>" +
+                "</ac:link> to the target page.</p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithInterDocumentCrossReferenceToTargetPageWithHtmlCharacterInTitle_returnsConfluencePageWithLinkToReferencedPageByPageTitle() {
         // arrange
         Path rootFolder = copyAsciidocSourceToTemporaryFolder("src/test/resources/inter-document-cross-references");

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/source-page-reference-with-anchor.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/source-page-reference-with-anchor.adoc
@@ -1,0 +1,3 @@
+= Source Page
+
+This is a <<target-page.adoc#_anchor,reference with anchor>> to the target page.

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/target-page-with-anchor.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/target-page-with-anchor.adoc
@@ -1,0 +1,6 @@
+= Target Page
+
+This is the target page with an:
+
+[[_anchor]]
+Anchor

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/01-pages.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/01-pages.adoc
@@ -43,6 +43,17 @@ referencing AsciiDoc file. All referenced AsciiDoc files must be placed below th
 <<01-pages.adoc#, Link to Pages>>
 <<../00-index/06-images.adoc#, Link to Images>>
 
+Links to other pages may also point to anchors within those pages. Either defined inline anchors or implicit anchor generated from headlines.
+
+[listing]
+....
+<<01-pages.adoc#paragraph-a], Link to Pages with inline anchor>>
+<<../00-index/06-images.adoc#_inline_images, Link to Images with headline anchor>>
+....
+
+<<01-pages.adoc#paragraph-a, Link to Pages with inline anchor>>
+<<../00-index/06-images.adoc#_inline_images, Link to Images with headline anchor>>
+
 
 == Links within Pages
 
@@ -86,9 +97,3 @@ Paragraph with internal cross-reference to <<section-b>>
 === Section with Custom Id
 
 Paragraph with internal cross-reference to <<section-b>>
-
-
-[WARNING]
-====
-Links from one page to an inline anchor within another page are currently not supported.
-====


### PR DESCRIPTION
This MR fixes #270 
Cross references with or without anchors are now rendered correctly and anchors are correctly navigated.
Tested cross-page references using different formats and all work correct with the changes:
 <<page.adoc#,reference>> 
 <<page.adoc#_anchor,reference>> 
xref:page.adoc[reference]
xref:page.adoc#_anchor[reference]

Internal Cross references on same page also keep working:
<<_anchor,reference>>

Tested with some quite complex page tree with references we used internally (Tested on Confluence 7.16.5).
