### PR TITLE
Add the ability to retain build pages after the command exits

### DIFF
--- a/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClientIntegrationTest.java
+++ b/asciidoc-confluence-publisher-cli/src/it/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClientIntegrationTest.java
@@ -19,7 +19,9 @@ package org.sahli.asciidoc.confluence.publisher.cli;
 import io.restassured.specification.RequestSpecification;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
@@ -35,6 +37,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.testcontainers.containers.Network.SHARED;
 import static org.testcontainers.containers.wait.strategy.Wait.forListeningPort;
+import static org.junit.Assert.assertTrue;
 
 public class AsciidocConfluencePublisherCommandLineClientIntegrationTest {
 
@@ -226,6 +229,30 @@ public class AsciidocConfluencePublisherCommandLineClientIntegrationTest {
         givenAuthenticatedAsPublisher()
                 .when().get(childPagesFor("327706"))
                 .then().body("results", hasSize(0));
+    }
+
+    @Rule
+    public TemporaryFolder buildDirectory = new TemporaryFolder();
+
+    @Test
+    public void publish_withConvertOnlyAndBuildDirectory_doesNotDeleteTheBuildDirectory() throws Exception {
+        // arrange
+        String[] args = {
+                "rootConfluenceUrl=http://localhost:8090",
+                "username=confluence-publisher-it",
+                "password=1234",
+                "spaceKey=CPI",
+                "ancestorId=327706",
+                "asciidocRootFolder=src/it/resources/default",
+                "convertOnly=true",
+                "asciidocBuildFolder="+buildDirectory.getRoot().getAbsolutePath()
+        };
+
+        // act
+        AsciidocConfluencePublisherCommandLineClient.main(args);
+
+        // assert
+        assertTrue("Build directory was deleted", buildDirectory.getRoot().exists());
     }
 
     private static String pageIdBy(String title) {

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -375,6 +375,10 @@ have to be mounted to the `/var/asciidoc-root-folder` volume.
 In case your documentation sources are already available under a different path in your Docker container, you can
 specify the path to the documentation sources via the environment variable `ASCIIDOC_ROOT_FOLDER`.
 
+The generated Confluence XHTML will be stored in a temporary directory inside the container, and will be deleted after command exits.
+To keep the generated pages, for inspection, set `ASCIIDOC_BUILD_FOLDER` to a path that is mounted into
+the container. This path will _not_ be deleted after the command exits.
+
 All other mandatory and optional configuration properties from the Maven plugin have to be / can be specified as
 environment variable in all-uppercase writing, e.g. `ROOT_CONFLUENCE_URL` for `rootConfluenceUrl`.
 
@@ -424,7 +428,11 @@ publish-docs:
   variables:
     ASCIIDOC_ROOT_FOLDER: ./docs/
     ROOT_CONFLUENCE_URL: http://confluence-host
+    ASCIIDOC_BUILD_FOLDER: $CI_PROJECT_DIR/build/docs
     ...
   script:
     - publish.sh
+  archive:
+    paths:
+    - $CI_PROJECT_DIR/build/docs
 ----

--- a/asciidoc-confluence-publisher-docker/publish.sh
+++ b/asciidoc-confluence-publisher-docker/publish.sh
@@ -22,4 +22,5 @@ exec java -jar /opt/asciidoc-confluence-publisher-docker.jar \
     proxyPort="$PROXY_PORT" \
     proxyUsername="$PROXY_USERNAME" \
     proxyPassword="$PROXY_PASSWORD" \
-    convertOnly="$CONVERT_ONLY"
+    convertOnly="$CONVERT_ONLY" \
+    asciidocBuildFolder="$ASCIIDOC_ROOT_FOLDER"


### PR DESCRIPTION
This allows the Confluence XHTML to be inspected, especilly as part of a Merge Request/Pull Request workflow before being pushed into a Confluence Server.