### PR TITLE
Allow images on borders

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
@@ -1,5 +1,5 @@
 = html_a_tag_if (attr? :link)
-  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(title if title?)
+  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(title if title?) ac:border=(attr :border if attr :border)
     - if uriish? attr :target
       ri:url ri:value=(attr :target)
     - else

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
@@ -1,5 +1,5 @@
 = html_a_tag_if (attr? :link)
-  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:alt=(attr :alt if attr :alt)
+  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:alt=(attr :alt if attr :alt) ac:border=(attr :border if attr :border)
     - if uriish? target
       ri:url ri:value=(target)
     - else

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -725,6 +725,19 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithImage_returnsConfluencePageContentWithImageAndBorder() {
+        // arrange
+        String adocContent = "image::sunset.jpg[border=true]";
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ac:image ac:border=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithImageInDifferentFolder_returnsConfluencePageContentWithImageAttachmentFileNameOnly() {
         // arrange
         String adocContent = "image::sub-folder/sunset.jpg[]";
@@ -1382,6 +1395,20 @@ public class AsciidocConfluencePageTest {
 
         // assert
         String expectedContent = "<p>Some text <ac:image ac:alt=\"sunset\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image> with inline image</p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithInlineImage_returnsConfluencePageWithInlineImageAndBorder() {
+        // arrange
+        String adocContent = "Some text image:sunset.jpg[border=true] with inline image";
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<p>Some text <ac:image ac:alt=\"sunset\" ac:border=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/06-images.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/06-images.adoc
@@ -79,3 +79,23 @@ This image has a link image:../images/frisbee.png[width=16, height=16, link=http
 ....
 
 This image has a link image:../images/frisbee.png[width=16, height=16, link=https://en.wikipedia.org/wiki/Frisbee].
+
+== Borders
+
+Block images can have a border added.
+
+[listing]
+....
+image::../images/frisbee.png[border]
+....
+
+image::../images/frisbee.png[border]
+
+So can inline images:
+
+[listing]
+....
+This line has an inline image image:../images/frisbee.png[width=16, height=16, border].
+....
+
+This line has an inline image image:../images/frisbee.png[width=16, height=16, border] within a text block.


### PR DESCRIPTION
Our documentation standards require our Confluence images to have borders around them. There is not currently a way to do this, but adding it to the processer is not complex.

This adds support for a `border=true` attribute to the image macro which emits an `ac:border="true` attribute on the resulting `ac:image` tag.