### PR TITLE
Fix #358 Underline and Strikethough are not rendered

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_quoted.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_quoted.html.slim
@@ -1,0 +1,27 @@
+- if role == "strike-through"
+  s
+    = text
+- elsif role == "underline"
+  u
+    = text
+- elsif type == :strong
+  strong
+    = text
+- elsif type == :emphasis
+  em
+    = text
+- elsif type == :monospace
+  code
+    = text
+- elsif type == :mark
+  mark
+    = text
+- elsif type == :superscript
+  sup
+    = text
+- elsif type == :subscript
+  sub
+    = text
+- else
+  span class=(role)
+    = text

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1831,6 +1831,47 @@ public class AsciidocConfluencePageTest {
         assertTrue(exists(assetsTargetFolderFor(asciidocPage).resolve("embedded-c4-diagram.png")));
     }
 
+
+    @Test
+    public void attachments_asciiDocWithStrikeThrough() {
+        // arrange
+        String adocContent = "normal1 [.strike-through]#strike trough# normal2";
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        String expectedContent = "<p>normal1 <s>strike trough</s> normal2</p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void attachments_asciiDocWithUnderline() {
+        // arrange
+        String adocContent = "normal1 [.underline]#underlined# normal2";
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        String expectedContent = "<p>normal1 <u>underlined</u> normal2</p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void attachments_asciiDocWithUnderline_multiline() {
+        // arrange
+        String adocContent = "normal1 [.underline]#underlined line1\n" +
+            "underlined line2# normal2";
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        String expectedContent = "<p>normal1 <u>underlined line1\nunderlined line2</u> normal2</p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
     private static String prependTitle(String content) {
         if (!content.startsWith("= ")) {
             content = "= Default Page Title\n\n" + content;


### PR DESCRIPTION
using a custom inline_quoted.html.slim to convert underline and strike-through to corresponding confluence tags u and s. 

Alternative solution to PR #361  to fix #358 
