### PR TITLE
Use SDKMAN! to set the JDK version to be used

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.22-tem


### PR DESCRIPTION
IntelliJ will automatically choose the correct JDK version to use (if .sdkmanrc is present), or from the command-line run sdk env.

```
$ sdk env
Using java version 11.0.22-tem in this shell.
```
