### PR TITLE
Fixes #444 - Toplevel Title is not acknowledged when included

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1074,6 +1074,22 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithInterDocumentCrossReference_returnsConfluencePageWithLinkToReferencedPageByPageTitleAcknowledgingIncludes() {
+        // arrange
+        Path rootFolder = copyAsciidocSourceToTemporaryFolder("src/test/resources/inter-document-cross-references");
+        AsciidocPage asciidocPage = asciidocPage(rootFolder, "source-page-with-title-in-include.adoc");
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage), "TEST");
+
+        // assert
+        String expectedContent = "<p>This is a <ac:link><ri:page ri:content-title=\"Target Page\" ri:space-key=\"TEST\"></ri:page>" +
+                "<ac:plain-text-link-body><![CDATA[reference]]></ac:plain-text-link-body>" +
+                "</ac:link> to the target page.</p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithInterDocumentCrossReferenceAnchor_returnsConfluencePageWithLinkToReferencedPageByPageTitleWithAnchor() {
         // arrange
         Path rootFolder = copyAsciidocSourceToTemporaryFolder("src/test/resources/inter-document-cross-references");

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1073,7 +1073,6 @@ public class AsciidocConfluencePageTest {
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
-    // This is basically just a check if the base-dir was set correctly in the options instance used to parse the referenced page
     @Test
     public void renderConfluencePage_asciiDocWithInterDocumentCrossReference_returnsConfluencePageWithLinkToReferencedPageByPageTitleAcknowledgingIncludes() {
         // arrange
@@ -1090,6 +1089,7 @@ public class AsciidocConfluencePageTest {
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
+    // This is basically just a check if the base-dir was set correctly in the options instance used to parse the referenced page
     @Test
     public void renderConfluencePage_asciiDocWithInterDocumentCrossReferenceInSubDirectory_returnsConfluencePageWithLinkToReferencedPageByPageTitleAcknowledgingIncludes() {
         // arrange

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1073,11 +1073,28 @@ public class AsciidocConfluencePageTest {
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
+    // This is basically just a check if the base-dir was set correctly in the options instance used to parse the referenced page
     @Test
     public void renderConfluencePage_asciiDocWithInterDocumentCrossReference_returnsConfluencePageWithLinkToReferencedPageByPageTitleAcknowledgingIncludes() {
         // arrange
         Path rootFolder = copyAsciidocSourceToTemporaryFolder("src/test/resources/inter-document-cross-references");
         AsciidocPage asciidocPage = asciidocPage(rootFolder, "source-page-with-title-in-include.adoc");
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage), "TEST");
+
+        // assert
+        String expectedContent = "<p>This is a <ac:link><ri:page ri:content-title=\"Target Page\" ri:space-key=\"TEST\"></ri:page>" +
+                "<ac:plain-text-link-body><![CDATA[reference]]></ac:plain-text-link-body>" +
+                "</ac:link> to the target page.</p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithInterDocumentCrossReferenceInSubDirectory_returnsConfluencePageWithLinkToReferencedPageByPageTitleAcknowledgingIncludes() {
+        // arrange
+        Path rootFolder = copyAsciidocSourceToTemporaryFolder("src/test/resources/inter-document-cross-references");
+        AsciidocPage asciidocPage = asciidocPage(rootFolder, "source-page-with-title-in-include-in-subdir.adoc");
 
         // act
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage), "TEST");

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/include-page-with-title-in-include.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/include-page-with-title-in-include.adoc
@@ -1,0 +1,1 @@
+= {title-key}

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/include-page-with-title-in-include.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/include-page-with-title-in-include.adoc
@@ -1,1 +1,1 @@
-= {title-key}
+= Target Page

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/source-page-with-title-in-include-in-subdir.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/source-page-with-title-in-include-in-subdir.adoc
@@ -1,0 +1,3 @@
+= Source Page
+
+This is a xref:subdir/target-page-with-title-in-include-relative-to-this-file.adoc[reference] to the target page.

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/source-page-with-title-in-include.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/source-page-with-title-in-include.adoc
@@ -1,0 +1,3 @@
+= Source Page
+
+This is a xref:target-page-with-title-in-include.adoc[reference] to the target page.

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/subdir/target-page-with-title-in-include-relative-to-this-file.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/subdir/target-page-with-title-in-include-relative-to-this-file.adoc
@@ -1,0 +1,1 @@
+include::../include-page-with-title-in-include.adoc[]

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/target-page-with-title-in-include.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/target-page-with-title-in-include.adoc
@@ -1,2 +1,1 @@
-:title-key: Target Page
 include::include-page-with-title-in-include.adoc[]

--- a/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/target-page-with-title-in-include.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/inter-document-cross-references/target-page-with-title-in-include.adoc
@@ -1,0 +1,2 @@
+:title-key: Target Page
+include::include-page-with-title-in-include.adoc[]


### PR DESCRIPTION
# The issue
When cross-referencing another file whose title is declared in an included file, this exception occurs: `java.lang.RuntimeException: top-level heading or title meta information must be set`

# The fix
Instead of parsing just the title, the whole document is parsed

Fixes #444 