### PR TITLE
[FIX] allow [.text-<allign>] in headers(section)

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
@@ -1,4 +1,18 @@
 - if title?
   div class="cp-paragraph-title"
     em =title
-p =content
+
+- case (role)
+- when 'text-left'
+    - confluence_alignment = 'left'
+- when 'text-right'
+    - confluence_alignment = 'right'
+- when 'text-center'
+    - confluence_alignment = 'center'
+- when 'text-justify'
+    - confluence_alignment = 'justify'
+
+- if confluence_alignment
+  *{tag: %(p), align: "#{confluence_alignment}"}  =content
+- else
+  *{tag: %(p)} =content

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_paragraph.html.slim
@@ -4,15 +4,15 @@
 
 - case (role)
 - when 'text-left'
-    - confluence_alignment = 'left'
+    - confluence_alignment = 'text-align: left;'
 - when 'text-right'
-    - confluence_alignment = 'right'
+    - confluence_alignment = 'text-align: right;'
 - when 'text-center'
-    - confluence_alignment = 'center'
+    - confluence_alignment = 'text-align: center;'
 - when 'text-justify'
-    - confluence_alignment = 'justify'
+    - confluence_alignment = 'text-align: justify;'
 
 - if confluence_alignment
-  *{tag: %(p), align: "#{confluence_alignment}"}  =content
+  *{tag: %(p), style: "#{confluence_alignment}"}  =content
 - else
   *{tag: %(p)} =content

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/helpers.rb
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/helpers.rb
@@ -209,5 +209,4 @@ module Slim::Helpers
       str
     end
   end
-
 end

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/section.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/section.html.slim
@@ -8,9 +8,17 @@
 - when 'text-justify'
     - confluence_alignment = 'text-align: justify;'
 
-*{tag: %(h#{section_level}), style: "#{confluence_alignment}" }
-  ac:structured-macro ac:name="anchor"
-    ac:parameter ac:name=""
-     =(anchor_name id)
-  =section_title
-=content
+- if confluence_alignment
+  *{tag: %(h#{section_level}), style: "#{confluence_alignment}" }
+    ac:structured-macro ac:name="anchor"
+      ac:parameter ac:name=""
+       =(anchor_name id)
+    =section_title
+  =content
+- else
+  *{tag: %(h#{section_level})}
+    ac:structured-macro ac:name="anchor"
+      ac:parameter ac:name=""
+       =(anchor_name id)
+    =section_title
+  =content

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/section.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/section.html.slim
@@ -1,4 +1,14 @@
-*{tag: %(h#{section_level})}
+- case (role)
+- when 'text-left'
+    - confluence_alignment = 'text-align: left;'
+- when 'text-right'
+    - confluence_alignment = 'text-align: right;'
+- when 'text-center'
+    - confluence_alignment = 'text-align: center;'
+- when 'text-justify'
+    - confluence_alignment = 'text-align: justify;'
+
+*{tag: %(h#{section_level}), style: "#{confluence_alignment}" }
   ac:structured-macro ac:name="anchor"
     ac:parameter ac:name=""
      =(anchor_name id)

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -671,11 +671,11 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_1</ac:parameter></ac:structured-macro>Title level 1</h1>" +
-                "<h2 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_2</ac:parameter></ac:structured-macro>Title level 2</h2>" +
-                "<h3 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_3</ac:parameter></ac:structured-macro>Title level 3</h3>" +
-                "<h4 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_4</ac:parameter></ac:structured-macro>Title level 4</h4>" +
-                "<h5 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_5</ac:parameter></ac:structured-macro>Title level 5</h5>";
+        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_1</ac:parameter></ac:structured-macro>Title level 1</h1>" +
+                "<h2><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_2</ac:parameter></ac:structured-macro>Title level 2</h2>" +
+                "<h3><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_3</ac:parameter></ac:structured-macro>Title level 3</h3>" +
+                "<h4><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_4</ac:parameter></ac:structured-macro>Title level 4</h4>" +
+                "<h5><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_5</ac:parameter></ac:structured-macro>Title level 5</h5>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1557,7 +1557,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
                 "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
@@ -1573,7 +1573,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
                 "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
@@ -1588,7 +1588,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
                 "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
@@ -1603,7 +1603,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
                 "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
@@ -1651,7 +1651,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_references</ac:parameter></ac:structured-macro>References</h1><ul>" +
+        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_references</ac:parameter></ac:structured-macro>References</h1><ul>" +
                 "<li><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">pp</ac:parameter></ac:structured-macro>[pp] Entry1</li>" +
                 "<li><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">gof</ac:parameter></ac:structured-macro>[gof] Entry2</li></ul>\n" +
                 "<p>Cross reference to <ac:link ac:anchor=\"pp\"><ac:plain-text-link-body><![CDATA[[pp]]]></ac:plain-text-link-body></ac:link>" +
@@ -1918,6 +1918,57 @@ public class AsciidocConfluencePageTest {
         String expectedContentPattern = "<ac:image ac:height=\"[1-9][0-9]*\" ac:width=\"[1-9][0-9]*\"><ri:attachment ri:filename=\"embedded-c4-diagram.png\"></ri:attachment></ac:image>";
         assertThat(asciidocConfluencePage.content(), matchesPattern(expectedContentPattern));
         assertTrue(exists(assetsTargetFolderFor(asciidocPage).resolve("embedded-c4-diagram.png")));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithSectionLevelAndAlign_returnsConfluencePageContentWithSectionAndAlignHavingCorrectMarkup() {
+        // arrange
+        String adocContent = "= Title level 0\n\n" +
+                "[.text-center]\n" +
+                "== Title level 1\n" +
+                "[.text-right]\n" +
+                "== Title level 2\n";
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<h1 style=\"text-align: center;\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_1</ac:parameter></ac:structured-macro>Title level 1</h1>\n"+
+            "<h1 style=\"text-align: right;\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_2</ac:parameter></ac:structured-macro>Title level 2</h1>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithSectionLevelAndParagrafAlign_returnsConfluencePageContentWithSectionAndParagrafAlignHavingCorrectMarkup() {
+        // arrange
+        String adocContent = "= Main Page\n\n" +
+            "This is demo string 0.0\n" +
+            "This is demo string 0.1\n" +
+            "This is demo string 0.2\n" +
+            "This is demo string 0.3\n\n" +
+            "== Demo\n\n" +
+            "This is demo string 1\n" +
+            "[.text-center]\n" +
+            "== Demo Size\n\n" +
+            "[.text-right]\n" +
+            "This is demo string 2\n\n" +
+            "[.text-center]\n" +
+            "This is demo string 3\n\n" +
+            "[.text-left]\n" +
+            "This is demo string 4\n\n" +
+            "[.text-justify]\n" +
+            "This is demo string 5\n";
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<div id=\"preamble\">\n<div class=\"sectionbody\">\n<p>This is demo string 0.0\nThis is demo string 0.1\nThis is demo string 0.2\n" + 
+            "This is demo string 0.3</p>\n</div>\n</div>\n<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_demo</ac:parameter></ac:structured-macro>Demo</h1>" +
+            "<p>This is demo string 1</p>\n<h1 style=\"text-align: center;\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_demo_size</ac:parameter>" + 
+            "</ac:structured-macro>Demo Size</h1><p align=\"right\">This is demo string 2</p>\n<p align=\"center\">This is demo string 3</p>\n<p align=\"left\">" + 
+            "This is demo string 4</p>\n<p align=\"justify\">This is demo string 5</p>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
     private static String prependTitle(String content) {

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1963,11 +1963,14 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<div id=\"preamble\">\n<div class=\"sectionbody\">\n<p>This is demo string 0.0\nThis is demo string 0.1\nThis is demo string 0.2\n" + 
-            "This is demo string 0.3</p>\n</div>\n</div>\n<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_demo</ac:parameter></ac:structured-macro>Demo</h1>" +
-            "<p>This is demo string 1</p>\n<h1 style=\"text-align: center;\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_demo_size</ac:parameter>" + 
-            "</ac:structured-macro>Demo Size</h1><p align=\"right\">This is demo string 2</p>\n<p align=\"center\">This is demo string 3</p>\n<p align=\"left\">" + 
-            "This is demo string 4</p>\n<p align=\"justify\">This is demo string 5</p>";
+        String expectedContent = "<div id=\"preamble\">\n<div class=\"sectionbody\">\n" +
+            "<p>This is demo string 0.0\nThis is demo string 0.1\nThis is demo string 0.2\nThis is demo string 0.3</p>\n" +
+            "</div>\n</div>\n<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_demo</ac:parameter>" +
+            "</ac:structured-macro>Demo</h1><p>This is demo string 1</p>\n<h1 style=\"text-align: center;\">" + 
+            "<ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_demo_size</ac:parameter>" + 
+            "</ac:structured-macro>Demo Size</h1><p style=\"text-align: right;\">This is demo string 2</p>\n" +
+            "<p style=\"text-align: center;\">This is demo string 3</p>\n<p style=\"text-align: left;\">This is demo string 4</p>\n" + 
+            "<p style=\"text-align: justify;\">This is demo string 5</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -671,11 +671,11 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_1</ac:parameter></ac:structured-macro>Title level 1</h1>" +
-                "<h2><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_2</ac:parameter></ac:structured-macro>Title level 2</h2>" +
-                "<h3><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_3</ac:parameter></ac:structured-macro>Title level 3</h3>" +
-                "<h4><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_4</ac:parameter></ac:structured-macro>Title level 4</h4>" +
-                "<h5><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_5</ac:parameter></ac:structured-macro>Title level 5</h5>";
+        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_1</ac:parameter></ac:structured-macro>Title level 1</h1>" +
+                "<h2 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_2</ac:parameter></ac:structured-macro>Title level 2</h2>" +
+                "<h3 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_3</ac:parameter></ac:structured-macro>Title level 3</h3>" +
+                "<h4 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_4</ac:parameter></ac:structured-macro>Title level 4</h4>" +
+                "<h5 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_title_level_5</ac:parameter></ac:structured-macro>Title level 5</h5>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1557,7 +1557,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
                 "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
@@ -1573,7 +1573,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
                 "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
@@ -1588,7 +1588,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
                 "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[Section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
@@ -1603,7 +1603,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
+        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">section-1</ac:parameter></ac:structured-macro>Section 1</h1>" +
                 "<p>Cross reference to <ac:link ac:anchor=\"section-1\"><ac:plain-text-link-body><![CDATA[section 1]]></ac:plain-text-link-body></ac:link></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
@@ -1651,7 +1651,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<h1><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_references</ac:parameter></ac:structured-macro>References</h1><ul>" +
+        String expectedContent = "<h1 style=\"\"><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">_references</ac:parameter></ac:structured-macro>References</h1><ul>" +
                 "<li><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">pp</ac:parameter></ac:structured-macro>[pp] Entry1</li>" +
                 "<li><ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">gof</ac:parameter></ac:structured-macro>[gof] Entry2</li></ul>\n" +
                 "<p>Cross reference to <ac:link ac:anchor=\"pp\"><ac:plain-text-link-body><![CDATA[[pp]]]></ac:plain-text-link-body></ac:link>" +

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/03-sections.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/03-sections.adoc
@@ -40,3 +40,17 @@ AsciiDoc sections are translated to the corresponding Confluence heading:
 ....
 
 ====== Section Level 5
+
+== Align text in section 
+
+The name of the role follows the pattern text-<alignment>, where <alignment> is one of left, center, right, or justify (e.g., text-center). Work in paragraph and section.
+
+.Example Assign text-center to a section
+[listing]
+....
+[.text-center]
+== This text is centered, so it must be important.
+....
+
+[.text-center]
+== This text is centered, so it must be important.

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/04-paragraphs.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/04-paragraphs.adoc
@@ -46,3 +46,18 @@ The title of a paragraph will rendered using a custom CSS class `cp-paragraph-ti
 
 .This the title of a paragraph
 The title of a paragraph will rendered using a custom CSS class `cp-paragraph-title`
+
+
+== Align text in paragraph 
+
+The name of the role follows the pattern text-<alignment>, where <alignment> is one of left, center, right, or justify (e.g., text-center).
+
+.Example Assign text-center to a paragraph
+[listing]
+....
+[.text-center]
+This text is centered, so it must be important.
+....
+
+[.text-center]
+This text is centered, so it must be important.


### PR DESCRIPTION
Need support feature [.text-<allign>] for section in confluence

Resolves #456 