### PR TITLE
Update plantuml to 1.2025.0 to make it work with Intellij's plantuml preview again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ target/
 .settings
 .classpath
 .factorypath
+/.run/asciidoc-confluence-publisher [clean compile].run.xml
+

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@ image:https://img.shields.io/maven-central/v/org.sahli.asciidoc.confluence.publi
 image:https://img.shields.io/circleci/project/github/confluence-publisher/confluence-publisher/master.svg["Build Status", link="https://circleci.com/gh/confluence-publisher/confluence-publisher/tree/master"]
 image:https://coveralls.io/repos/github/confluence-publisher/confluence-publisher/badge.svg?branch=master["Coverage Status", link="https://coveralls.io/github/confluence-publisher/confluence-publisher?branch=master"]
 
-= Confluence Publisher
+== Confluence Publisher
 
 The Confluence Publisher allows documentation written in AsciiDoc and versioned directly with the documented code base
 to be published to a Confluence space. It supports a "docs-as-code" approach.

--- a/asciidoc-confluence-publisher-converter/pom.xml
+++ b/asciidoc-confluence-publisher-converter/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>net.sourceforge.plantuml</groupId>
             <artifactId>plantuml</artifactId>
-            <version>1.2023.5</version>
+            <version>1.2025.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/asciidoc-confluence-publisher-converter/src/test/resources/plantuml/included-diagram.puml
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/plantuml/included-diagram.puml
@@ -1,3 +1,14 @@
 @startuml
-A <|-- B
+!pragma layout smetana
+!include <tupadr3/common.puml>
+' the mysql icon was moved and renamed between git@github.com:tupadr3/plantuml-icon-font-sprites.git version 2.x and 3.x
+' with  2.x and therefore plantuml 1.2023.5 the following include used to work
+'!include <tupadr3/devicons2/mysql>
+!include <tupadr3/devicons2/mysql_original>
+!include <tupadr3/font-awesome-5/server>
+FA5_SERVER(A,"label")
+DEV2_MYSQL_ORIGINAL(B,"label")
+' with plantuml 1.2023.5 the following include used to work instead
+'DEV2_MYSQL(B,"label")
+A --|> B
 @enduml


### PR DESCRIPTION
The  plantuml version 1.2023.5 is quite old, and there was a change in in some locations of sprites of the plantuml-std-library. 

Among others the `mysql` icon was moved and renamed in  `git@github.com:tupadr3/plantuml-icon-font-sprites.git` 
between version 2.x and 3.x.

* plantuml version `1.2023.5` uses tupadr3/plantuml-icon-font-sprites version `2.x`  
* plantuml version `1.2025.0` uses tupadr3/plantuml-icon-font-sprites version `3.x ` 

therefore : the `mysql` icon worked in plantuml version 1.2023.5 like this:
```
!include <tupadr3/devicons2/mysql>
DEV2_MYSQL(B,"label")
```
but now with `1.2025.0` you need to use this
```
!include <tupadr3/devicons2/mysql_original>
DEV2_MYSQL_ORIGINAL(B,"label")
```

Unfortunately the Intellij plantuml plugin already uses a newer plantuml version  which in turn uses the newer `tupadr3/plantuml-icon-font-sprites` version `3.x`  

so when you create a plantuml file (or asciidoc with included plantuml ) in your Intellij IDE with the plantuml plugin you need to use the newer `!include  <..>` shown above . 

But the confluence-publisher maven plugin still wants to have the old version, which prevents you from having a preview in Intellij (because then Intellij complains about not being able to find the old  `!include  <..>`)  

Therefore i propose to upgrade the plantuml version used in this project  to `1.2025.0`

I also added this 
```
!include <tupadr3/devicons2/mysql_original>
DEV2_MYSQL_ORIGINAL(B,"label")
```
to one of the test `.puml` test files, this test will only succeed now if the newer plantuml version `1.2025.0` is defined in the `pom.xml`