### PR TITLE
Allow exteding the classpath of the docker image

### DIFF
--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -30,6 +30,7 @@ Currently, the Confluence Publisher supports the following AsciiDoc features:
 * <<00-index/11-attachments.adoc#, Attachments>>
 * <<00-index/12-table-of-contents.adoc#, Table of Contents>>
 * <<00-index/13-additional-features.adoc#, Additional Features>>
+* <<00-index/14-extensions.adoc#, Extensions>>
 
 The Confluence Publisher uses AsciidoctorJ and therefore supports documentation written using the Asciidoctor syntax.
 See link:http://asciidoctor.org/docs/user-manual/[Asciidoctor User Manual] for more information about Asciidoctor.

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/14-extensions.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/14-extensions.adoc
@@ -1,0 +1,54 @@
+= Extensions
+
+The Confluence Publisher supports https://docs.asciidoctor.org/asciidoctorj/latest/extensions/extensions-introduction/[AsciiDoctorJ Extensions]. These need to be written in Java, and build into a jar file as outlined in the AsciiDoctorJ Extension Guide.
+
+== Extensions in Maven
+
+In maven extensions can be added by extending the classpath of the maven plugin.
+
+[source,xml]
+----
+<plugin>
+  <groupId>org.sahli.asciidoc.confluence.publisher</groupId>
+  <artifactId>asciidoc-confluence-publisher-maven-plugin</artifactId>
+  <version>${asciidoc-confluence-publisher-maven-plugin.version}</version>
+  <dependencies>
+    <dependency>
+      <groupId>my-extension-group-id</groupId>
+      <artifactId>my-extension-artifact-id</artifactId>
+      <version>my-extension-version</version>
+    </dependency>
+  </dependencies>
+</plugin>
+----
+
+== Extensions in the Docker Image
+
+Once the extension has been written it can be put into the `/opt/extensions` folder inside the provided container image and they will be automatically loaded.
+
+For example:
+
+----
+docker run --rm -e ROOT_CONFLUENCE_URL=http://confluence-host \
+   -v /extension.jar:/opt/extensions/extension.jar \
+   -e SKIP_SSL_VERIFICATION=false \
+   -e MAX_REQUESTS_PER_SECOND=10 \
+   -e CONNECTION_TIME_TO_LIVE=500 \
+   -e USERNAME=username \
+   -e PASSWORD=1234 \
+   -e SPACE_KEY=XYZ \
+   -e ANCESTOR_ID=012345 \
+   -e PAGE_TITLE_PREFIX="Draft - " \
+   -e PAGE_TITLE_SUFFIX=" (V 1.0)" \
+   -e PUBLISHING_STRATEGY=REPLACE_ANCESTOR \
+   -e ORPHAN_REMOVAL_STRATEGY=KEEP_ORPHANS \
+   -e VERSION_MESSAGE="V 1.0" \
+   -e NOTIFY_WATCHERS=true \
+   -e ATTRIBUTES='{"attribute1": "value1", "attribute2": "value2"}' \
+   -e PROXY_SCHEME=https \
+   -e PROXY_HOST=my.proxy.com \
+   -e PROXY_PORT=8443 \
+   -e CONVERT_ONLY=false \
+   -v /absolute/path/to/asciidoc-root-folder:/var/asciidoc-root-folder \
+   confluencepublisher/confluence-publisher:0.0.0-SNAPSHOT
+----

--- a/asciidoc-confluence-publisher-docker/pom.xml
+++ b/asciidoc-confluence-publisher-docker/pom.xml
@@ -78,11 +78,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.sahli.asciidoc.confluence.publisher.cli.AsciidocConfluencePublisherCommandLineClient</mainClass>
-                        </manifest>
-                    </archive>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>

--- a/asciidoc-confluence-publisher-docker/publish.sh
+++ b/asciidoc-confluence-publisher-docker/publish.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
-exec java -jar /opt/asciidoc-confluence-publisher-docker.jar \
+exec java -cp "/opt/*:/opt/extensions/*" \
+    org.sahli.asciidoc.confluence.publisher.cli.AsciidocConfluencePublisherCommandLineClient \
     asciidocRootFolder="$ASCIIDOC_ROOT_FOLDER" \
     sourceEncoding="$SOURCE_ENCODING" \
     rootConfluenceUrl="$ROOT_CONFLUENCE_URL" \


### PR DESCRIPTION
Allow providing new extension (read custom macros) in the /opt/extensions folder inside the container. This allows extensions to be compiled and then mounted into the publisher.

This also changes the 'asciidoc-confluence-publisher-docker' jar from being a runnable jar, to regular jar. This change was made so there's only one place that has to be updated (in the docker modeule) if the main class name ever changes.

Closes: #460