### PR TITLE
Add `ac:custom-width` to images which has an explicit width or height.

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
@@ -1,5 +1,5 @@
 = html_a_tag_if (attr? :link)
-  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(title if title?) ac:border=(attr :border if attr :border)
+  ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(title if title?) ac:border=(attr :border if attr :border) ac:custom-width=("true" if attr(:width) || attr(:height))
     - if uriish? attr :target
       ri:url ri:value=(attr :target)
     - else

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
@@ -1,6 +1,6 @@
 = html_a_tag_if (attr? :link)
   span
-    ac:image ac:height=(attr :height) ac:width=(attr :width) ac:alt=(attr :alt if attr :alt) ac:border=(attr :border if attr :border)
+    ac:image ac:height=(attr :height) ac:width=(attr :width) ac:alt=(attr :alt if attr :alt) ac:border=(attr :border if attr :border) ac:custom-width=("true" if attr(:width) || attr(:height))
       - if uriish? target
         ri:url ri:value=(target)
       - else

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -740,7 +740,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<a href=\"http://www.foo.ch\"><ac:image ac:height=\"200\" ac:width=\"300\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></a>";
+        String expectedContent = "<a href=\"http://www.foo.ch\"><ac:image ac:height=\"200\" ac:width=\"300\" ac:custom-width=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></a>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1446,7 +1446,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
-        String expectedContentPattern = "<ac:image ac:height=\"[1-9][0-9]*\" ac:width=\"[1-9][0-9]*\"><ri:attachment ri:filename=\"embedded-diagram.png\"></ri:attachment></ac:image>";
+        String expectedContentPattern = "<ac:image ac:height=\"[1-9][0-9]*\" ac:width=\"[1-9][0-9]*\" ac:custom-width=\"true\"><ri:attachment ri:filename=\"embedded-diagram.png\"></ri:attachment></ac:image>";
         assertThat(asciidocConfluencePage.content(), matchesPattern(expectedContentPattern));
         assertTrue(exists(assetsTargetFolderFor(asciidocPage).resolve("embedded-diagram.png")));
     }
@@ -1461,7 +1461,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
-        String expectedContentPattern = "<ac:image ac:height=\"[1-9][0-9]*\" ac:width=\"[1-9][0-9]*\"><ri:attachment ri:filename=\"included-diagram.png\"></ri:attachment></ac:image>";
+        String expectedContentPattern = "<ac:image ac:height=\"[1-9][0-9]*\" ac:width=\"[1-9][0-9]*\" ac:custom-width=\"true\"><ri:attachment ri:filename=\"included-diagram.png\"></ri:attachment></ac:image>";
         assertThat(asciidocConfluencePage.content(), matchesPattern(expectedContentPattern));
     }
 
@@ -1609,7 +1609,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <a href=\"http://www.foo.ch\"><span><ac:image ac:height=\"20\" ac:width=\"16\" ac:alt=\"Sunset\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span></a> with inline image</p>";
+        String expectedContent = "<p>Some text <a href=\"http://www.foo.ch\"><span><ac:image ac:height=\"20\" ac:width=\"16\" ac:alt=\"Sunset\" ac:custom-width=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span></a> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1995,7 +1995,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
-        String expectedContentPattern = "<ac:image ac:height=\"[1-9][0-9]*\" ac:width=\"[1-9][0-9]*\"><ri:attachment ri:filename=\"embedded-c4-diagram.png\"></ri:attachment></ac:image>";
+        String expectedContentPattern = "<ac:image ac:height=\"[1-9][0-9]*\" ac:width=\"[1-9][0-9]*\" ac:custom-width=\"true\"><ri:attachment ri:filename=\"embedded-c4-diagram.png\"></ri:attachment></ac:image>";
         assertThat(asciidocConfluencePage.content(), matchesPattern(expectedContentPattern));
         assertTrue(exists(assetsTargetFolderFor(asciidocPage).resolve("embedded-c4-diagram.png")));
     }


### PR DESCRIPTION
This is required to have the new editor correctly render the size of images in the new editor. This is tracked in the Confluence Cloud Jira as <https://jira.atlassian.com/browse/CONFCLOUD-82061>

Issue: #475

This will conflict with the changes in #473 so whichever gets merged first I will rebase/update to then not conflict. 