### PR TITLE
Provide access to source file information

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverter.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverter.java
@@ -75,7 +75,8 @@ public final class AsciidocConfluenceConverter {
         AsciidocPagesStructureProvider.AsciidocPagesStructure structure = asciidocPagesStructureProvider.structure();
         List<AsciidocPage> asciidocPages = structure.pages();
         Charset sourceEncoding = asciidocPagesStructureProvider.sourceEncoding();
-        List<ConfluencePageMetadata> confluencePages = buildPageTree(templatesRootFolder, assetsRootFolder, asciidocPages, sourceEncoding, pageTitlePostProcessor, userAttributes, this.spaceKey);
+        Path rootFolder = asciidocPagesStructureProvider.rootFolder();
+        List<ConfluencePageMetadata> confluencePages = buildPageTree(templatesRootFolder, assetsRootFolder, asciidocPages, sourceEncoding, pageTitlePostProcessor, userAttributes, this.spaceKey, rootFolder);
 
         ConfluencePublisherMetadata confluencePublisherMetadata = new ConfluencePublisherMetadata();
         confluencePublisherMetadata.setSpaceKey(this.spaceKey);
@@ -85,21 +86,21 @@ public final class AsciidocConfluenceConverter {
         return confluencePublisherMetadata;
     }
 
-    private static List<ConfluencePageMetadata> buildPageTree(Path templatesRootFolder, Path assetsRootFolder, List<AsciidocPage> asciidocPages, Charset sourceEncoding, PageTitlePostProcessor pageTitlePostProcessor, Map<String, Object> userAttributes, String spaceKey) {
+    private static List<ConfluencePageMetadata> buildPageTree(Path templatesRootFolder, Path assetsRootFolder, List<AsciidocPage> asciidocPages, Charset sourceEncoding, PageTitlePostProcessor pageTitlePostProcessor, Map<String, Object> userAttributes, String spaceKey, Path rootFolder) {
         List<ConfluencePageMetadata> confluencePages = new ArrayList<>();
 
         asciidocPages.forEach((asciidocPage) -> {
             Path pageAssetsFolder = determinePageAssetsFolder(assetsRootFolder, asciidocPage);
             createDirectories(pageAssetsFolder);
 
-            AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, sourceEncoding, templatesRootFolder, pageAssetsFolder, pageTitlePostProcessor, userAttributes, spaceKey);
+            AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, sourceEncoding, templatesRootFolder, pageAssetsFolder, pageTitlePostProcessor, userAttributes, spaceKey, rootFolder);
             Path contentFileTargetPath = writeToTargetStructure(asciidocPage, pageAssetsFolder, asciidocConfluencePage);
 
             List<AttachmentMetadata> attachments = buildAttachments(asciidocPage, pageAssetsFolder, asciidocConfluencePage.attachments());
             copyAttachmentsAvailableInSourceStructureToTargetStructure(attachments);
             ensureAttachmentsExist(attachments);
 
-            List<ConfluencePageMetadata> childConfluencePages = buildPageTree(templatesRootFolder, assetsRootFolder, asciidocPage.children(), sourceEncoding, pageTitlePostProcessor, userAttributes, spaceKey);
+            List<ConfluencePageMetadata> childConfluencePages = buildPageTree(templatesRootFolder, assetsRootFolder, asciidocPage.children(), sourceEncoding, pageTitlePostProcessor, userAttributes, spaceKey, rootFolder);
             ConfluencePageMetadata confluencePageMetadata = buildConfluencePageMetadata(asciidocConfluencePage, contentFileTargetPath, childConfluencePages, attachments);
 
             confluencePages.add(confluencePageMetadata);

--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
@@ -236,9 +236,9 @@ public class AsciidocConfluencePage {
                 .attribute("imagesoutdir", generatedAssetsTargetFolder.toString())
                 .attribute("outdir", generatedAssetsTargetFolder.toString())
                 .attribute("source-highlighter", "none")
-                .attribute("confluencepublisher-source-file", relativeSourcePath.toString())
-                .attribute("confluencepublisher-source-file-name", fileName)
-                .attribute("confluencepublisher-source-file-name-without-extension", fileNameWithoutExtension)
+                .attribute("cp-source-path", relativeSourcePath.toString())
+                .attribute("cp-source-file", fileName)
+                .attribute("cp-source-name", fileNameWithoutExtension)
                 .build();
 
 

--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocPagesStructureProvider.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocPagesStructureProvider.java
@@ -26,6 +26,8 @@ public interface AsciidocPagesStructureProvider {
 
     Charset sourceEncoding();
 
+    Path rootFolder();
+
 
     interface AsciidocPagesStructure {
 

--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/FolderBasedAsciidocPagesStructureProvider.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/FolderBasedAsciidocPagesStructureProvider.java
@@ -36,8 +36,10 @@ public class FolderBasedAsciidocPagesStructureProvider implements AsciidocPagesS
 
     private final AsciidocPagesStructure structure;
     private final Charset sourceEncoding;
+    private final Path documentationRootFolder;
 
     public FolderBasedAsciidocPagesStructureProvider(Path documentationRootFolder, Charset sourceEncoding) {
+        this.documentationRootFolder = documentationRootFolder;
         this.structure = buildStructure(documentationRootFolder);
         this.sourceEncoding = sourceEncoding;
     }
@@ -50,6 +52,11 @@ public class FolderBasedAsciidocPagesStructureProvider implements AsciidocPagesS
     @Override
     public Charset sourceEncoding() {
         return this.sourceEncoding;
+    }
+
+    @Override
+    public Path rootFolder() {
+        return this.documentationRootFolder;
     }
 
     private AsciidocPagesStructure buildStructure(Path documentationRootFolder) {

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -251,7 +251,7 @@ public class AsciidocConfluencePageTest {
     @Test
     public void renderConfluencePage_asciiDocWithSourceFileAttributes_returnsConfluencePageContentWithSourceFileInfo() {
         // arrange
-        String adocContent = prependTitle("{confluencepublisher-source-file} {confluencepublisher-source-file-name} {confluencepublisher-source-file-name-without-extension}");
+        String adocContent = prependTitle("{cp-source-path} {cp-source-file} {cp-source-name}");
         
         // act
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -20,6 +20,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sahli.asciidoc.confluence.publisher.converter.AsciidocPagesStructureProvider.AsciidocPage;
+import org.sahli.asciidoc.confluence.publisher.converter.NoOpPageTitlePostProcessor;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -260,7 +261,7 @@ public class AsciidocConfluencePageTest {
         write(sourceFile, adocContent.getBytes(UTF_8));
         
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(sourceFile), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(sourceFile), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath(), new NoOpPageTitlePostProcessor(), emptyMap(), "", rootFolder);
         
         // assert
         assertThat(asciidocConfluencePage.content(), containsString("Path: docs/pages/user-guide.adoc")); // cp-source-path with prefix

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -257,8 +257,33 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
         
         // assert
-        assertThat(asciidocConfluencePage.content(), containsString("test-page.adoc"));
-        assertThat(asciidocConfluencePage.content(), containsString("test-page"));
+        assertThat(asciidocConfluencePage.content(), containsString("tmp/")); // relative path should contain tmp/ directory
+        assertThat(asciidocConfluencePage.content(), containsString(".adoc")); // cp-source-file should contain .adoc extension
+        assertThat(asciidocConfluencePage.content(), matchesPattern(".*\\b[a-f0-9]{64}\\b.*")); // cp-source-name should contain the hash without extension
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithSourceFileAttributesInSubdirectory_returnsConfluencePageContentWithCorrectRelativePath() {
+        // arrange
+        Path rootFolder = TEMPORARY_FOLDER.newFolder().toPath();
+        Path subDir = rootFolder.resolve("docs").resolve("pages");
+        String adocContent = prependTitle("Path: {cp-source-path}, File: {cp-source-file}, Name: {cp-source-name}");
+        Path sourceFile = subDir.resolve("user-guide.adoc");
+        
+        try {
+            createDirectories(subDir);
+            write(sourceFile, adocContent.getBytes(UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create test file structure", e);
+        }
+        
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(sourceFile), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        
+        // assert
+        assertThat(asciidocConfluencePage.content(), containsString("docs/pages/user-guide.adoc")); // cp-source-path
+        assertThat(asciidocConfluencePage.content(), containsString("user-guide.adoc")); // cp-source-file
+        assertThat(asciidocConfluencePage.content(), containsString("user-guide")); // cp-source-name
     }
 
     @Test

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -251,15 +251,18 @@ public class AsciidocConfluencePageTest {
     @Test
     public void renderConfluencePage_asciiDocWithSourceFileAttributes_returnsConfluencePageContentWithSourceFileInfo() {
         // arrange
-        String adocContent = prependTitle("{cp-source-path} {cp-source-file} {cp-source-name}");
+        String adocContent = prependTitle("Source path: {cp-source-path}, Source file: {cp-source-file}, Source name: {cp-source-name}");
         
         // act
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
         
         // assert
-        assertThat(asciidocConfluencePage.content(), containsString("tmp/")); // relative path should contain tmp/ directory
-        assertThat(asciidocConfluencePage.content(), containsString(".adoc")); // cp-source-file should contain .adoc extension
-        assertThat(asciidocConfluencePage.content(), matchesPattern(".*\\b[a-f0-9]{64}\\b.*")); // cp-source-name should contain the hash without extension
+        String content = asciidocConfluencePage.content();
+        assertThat(content, containsString("Source path: tmp/")); // cp-source-path with prefix
+        assertThat(content, containsString("Source file: "));
+        assertThat(content, containsString(".adoc")); // cp-source-file should contain .adoc extension
+        assertThat(content, containsString("Source name: "));
+        assertThat(content, matchesPattern(".*Source name: [a-f0-9]{64}.*")); // cp-source-name with prefix and hash
     }
 
     @Test
@@ -281,9 +284,9 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(sourceFile), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
         
         // assert
-        assertThat(asciidocConfluencePage.content(), containsString("docs/pages/user-guide.adoc")); // cp-source-path
-        assertThat(asciidocConfluencePage.content(), containsString("user-guide.adoc")); // cp-source-file
-        assertThat(asciidocConfluencePage.content(), containsString("user-guide")); // cp-source-name
+        assertThat(asciidocConfluencePage.content(), containsString("Path: docs/pages/user-guide.adoc")); // cp-source-path with prefix
+        assertThat(asciidocConfluencePage.content(), containsString("File: user-guide.adoc")); // cp-source-file with prefix
+        assertThat(asciidocConfluencePage.content(), containsString("Name: user-guide")); // cp-source-name with prefix
     }
 
     @Test

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -249,36 +249,15 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
-    public void renderConfluencePage_asciiDocWithSourceFileAttributes_returnsConfluencePageContentWithSourceFileInfo() {
-        // arrange
-        String adocContent = prependTitle("Source path: {cp-source-path}, Source file: {cp-source-file}, Source name: {cp-source-name}");
-        
-        // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
-        
-        // assert
-        String content = asciidocConfluencePage.content();
-        assertThat(content, containsString("Source path: tmp/")); // cp-source-path with prefix
-        assertThat(content, containsString("Source file: "));
-        assertThat(content, containsString(".adoc")); // cp-source-file should contain .adoc extension
-        assertThat(content, containsString("Source name: "));
-        assertThat(content, matchesPattern(".*Source name: [a-f0-9]{64}.*")); // cp-source-name with prefix and hash
-    }
-
-    @Test
-    public void renderConfluencePage_asciiDocWithSourceFileAttributesInSubdirectory_returnsConfluencePageContentWithCorrectRelativePath() {
+    public void renderConfluencePage_asciiDocWithSourceFileAttributesInSubdirectory_returnsConfluencePageContentWithCorrectRelativePath() throws IOException {
         // arrange
         Path rootFolder = TEMPORARY_FOLDER.newFolder().toPath();
         Path subDir = rootFolder.resolve("docs").resolve("pages");
         String adocContent = prependTitle("Path: {cp-source-path}, File: {cp-source-file}, Name: {cp-source-name}");
         Path sourceFile = subDir.resolve("user-guide.adoc");
         
-        try {
-            createDirectories(subDir);
-            write(sourceFile, adocContent.getBytes(UTF_8));
-        } catch (IOException e) {
-            throw new RuntimeException("Could not create test file structure", e);
-        }
+        createDirectories(subDir);
+        write(sourceFile, adocContent.getBytes(UTF_8));
         
         // act
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(sourceFile), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -249,6 +249,19 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithSourceFileAttributes_returnsConfluencePageContentWithSourceFileInfo() {
+        // arrange
+        String adocContent = prependTitle("{confluencepublisher-source-file} {confluencepublisher-source-file-name} {confluencepublisher-source-file-name-without-extension}");
+        
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adocContent), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        
+        // assert
+        assertThat(asciidocConfluencePage.content(), containsString("test-page.adoc"));
+        assertThat(asciidocConfluencePage.content(), containsString("test-page"));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithListing_returnsConfluencePageContentWithMacroWithNameNoFormat() {
         // arrange
         String adocContent = "----\n" +

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/13-additional-features.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/13-additional-features.adoc
@@ -77,7 +77,7 @@ The Confluence Publisher automatically exposes information about the source Asci
 This page was generated from: {cp-source-file}
 ....
 
-Output: This page was generated from: user-guide.adoc
+This page was generated from: {cp-source-file}
 
 ==== Use File Name in Document Title
 
@@ -86,7 +86,7 @@ Output: This page was generated from: user-guide.adoc
 = {cp-source-name} Documentation
 ....
 
-Output: = user-guide Documentation
+= {cp-source-name} Documentation
 
 ==== Reference Source File Path
 
@@ -95,4 +95,4 @@ Output: = user-guide Documentation
 Source file location: `{cp-source-path}`
 ....
 
-Output: Source file location: `pages/user-guide.adoc`
+Source file location: `{cp-source-path}`

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/13-additional-features.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/13-additional-features.adoc
@@ -45,3 +45,54 @@ specified example element.
 ====
 Using the `open` option on collapsible expand blocks is currently not supported.
 ====
+
+
+== Source File Information
+
+The confluence publisher automatically exposes information about the source AsciiDoc file being processed through built-in attributes. These attributes can be used in your AsciiDoc content to reference information about the current file:
+
+[cols="1,3,2"]
+|===
+|Attribute |Description |Example Value
+
+|`confluencepublisher-source-file`
+|The relative path of the source file from the base directory
+|`pages/user-guide.adoc`
+
+|`confluencepublisher-source-file-name`
+|The filename of the source file including extension
+|`user-guide.adoc`
+
+|`confluencepublisher-source-file-name-without-extension`
+|The filename of the source file without extension
+|`user-guide`
+|===
+
+=== Usage Examples
+
+==== Display Source File Name in Content
+
+[listing]
+....
+This page was generated from: {confluencepublisher-source-file-name}
+....
+
+Output: This page was generated from: user-guide.adoc
+
+==== Use File Name in Document Title
+
+[listing]
+....
+= {confluencepublisher-source-file-name-without-extension} Documentation
+....
+
+Output: = user-guide Documentation
+
+==== Reference Source File Path
+
+[listing]
+....
+Source file location: `{confluencepublisher-source-file}`
+....
+
+Output: Source file location: `pages/user-guide.adoc`

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/13-additional-features.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/13-additional-features.adoc
@@ -70,7 +70,12 @@ The Confluence Publisher automatically exposes information about the source Asci
 
 === Usage Examples
 
-==== Display Source File Name in Content
+[listing]
+....
+The source file path is: {cp-source-path}
+....
+
+The source file path is: {cp-source-path}
 
 [listing]
 ....
@@ -79,20 +84,9 @@ This page was generated from: {cp-source-file}
 
 This page was generated from: {cp-source-file}
 
-==== Use File Name in Document Title
-
 [listing]
 ....
-= {cp-source-name} Documentation
+The page name is: {cp-source-name}
 ....
 
-= {cp-source-name} Documentation
-
-==== Reference Source File Path
-
-[listing]
-....
-Source file location: `{cp-source-path}`
-....
-
-Source file location: `{cp-source-path}`
+The page name is: {cp-source-name}

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/13-additional-features.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/13-additional-features.adoc
@@ -49,21 +49,21 @@ Using the `open` option on collapsible expand blocks is currently not supported.
 
 == Source File Information
 
-The confluence publisher automatically exposes information about the source AsciiDoc file being processed through built-in attributes. These attributes can be used in your AsciiDoc content to reference information about the current file:
+The Confluence Publisher automatically exposes information about the source AsciiDoc file being processed through built-in attributes. These attributes can be used in your AsciiDoc content to reference information about the current file:
 
 [cols="1,3,2"]
 |===
 |Attribute |Description |Example Value
 
-|`confluencepublisher-source-file`
+|`cp-source-path`
 |The relative path of the source file from the base directory
 |`pages/user-guide.adoc`
 
-|`confluencepublisher-source-file-name`
+|`cp-source-file`
 |The filename of the source file including extension
 |`user-guide.adoc`
 
-|`confluencepublisher-source-file-name-without-extension`
+|`cp-source-name`
 |The filename of the source file without extension
 |`user-guide`
 |===
@@ -74,7 +74,7 @@ The confluence publisher automatically exposes information about the source Asci
 
 [listing]
 ....
-This page was generated from: {confluencepublisher-source-file-name}
+This page was generated from: {cp-source-file}
 ....
 
 Output: This page was generated from: user-guide.adoc
@@ -83,7 +83,7 @@ Output: This page was generated from: user-guide.adoc
 
 [listing]
 ....
-= {confluencepublisher-source-file-name-without-extension} Documentation
+= {cp-source-name} Documentation
 ....
 
 Output: = user-guide Documentation
@@ -92,7 +92,7 @@ Output: = user-guide Documentation
 
 [listing]
 ....
-Source file location: `{confluencepublisher-source-file}`
+Source file location: `{cp-source-path}`
 ....
 
 Output: Source file location: `pages/user-guide.adoc`


### PR DESCRIPTION
Exposes the following custom attributes:

- `cp-source-path`: relative file path from base directory
- `cp-source-file`: filename with extension
- `cp-source-name`: filename without extension

Resolves #248 