### PR TITLE
Fix inline image size in new Confluence editor

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
@@ -1,6 +1,6 @@
 = html_a_tag_if (attr? :link)
   span
-    ac:image ac:height=(attr :height) ac:width=(attr :width) ac:alt=(attr :alt if attr :alt) ac:border=(attr :border if attr :border) ac:custom-width=("true" if attr(:width) || attr(:height))
+    ac:image ac:height=(attr :height) ac:width=(attr :width) ac:alt=(attr :alt if attr :alt) ac:border=(attr :border if attr :border) ac:inline="true" ac:custom-width=("true" if attr(:width) || attr(:height))
       - if uriish? target
         ri:url ri:value=(target)
       - else

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1567,7 +1567,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <span><ac:image ac:alt=\"sunset\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span> with inline image</p>";
+        String expectedContent = "<p>Some text <span><ac:image ac:alt=\"sunset\" ac:inline=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1581,7 +1581,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <span><ac:image ac:alt=\"sunset\" ac:border=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span> with inline image</p>";
+        String expectedContent = "<p>Some text <span><ac:image ac:alt=\"sunset\" ac:border=\"true\" ac:inline=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1596,7 +1596,7 @@ public class AsciidocConfluencePageTest {
 
         // assert
         String expectedContent = "<p>Some text " +
-                "<span><ac:image ac:alt=\"GitHub mascot\">" +
+                "<span><ac:image ac:alt=\"GitHub mascot\" ac:inline=\"true\">" +
                 "<ri:url ri:value=\"https://asciidoctor.org/images/octocat.jpg\"></ri:url>" +
                 "</ac:image></span></p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
@@ -1630,7 +1630,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <a href=\"http://www.foo.ch\"><span><ac:image ac:height=\"20\" ac:width=\"16\" ac:alt=\"Sunset\" ac:custom-width=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span></a> with inline image</p>";
+        String expectedContent = "<p>Some text <a href=\"http://www.foo.ch\"><span><ac:image ac:height=\"20\" ac:width=\"16\" ac:alt=\"Sunset\" ac:inline=\"true\" ac:custom-width=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span></a> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1643,7 +1643,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <span><ac:image ac:alt=\"sunset\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span> with inline image</p>";
+        String expectedContent = "<p>Some text <span><ac:image ac:alt=\"sunset\" ac:inline=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/06-images.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/06-images.adoc
@@ -42,6 +42,10 @@ image::../images/frisbee.png[height=75]
 
 image::../images/frisbee.png[height=75]
 
+[NOTE]
+====
+Image sizes are only respected for block images. Inline image will render based on the font size of the surrounding text.
+====
 
 == Inline Images
 
@@ -49,10 +53,10 @@ Inline images are supported as well:
 
 [listing]
 ....
-This line has an inline image image:../images/frisbee.png[width=16, height=16].
+This line has an inline image image:../images/frisbee.png[].
 ....
 
-This line has an inline image image:../images/frisbee.png[width=16, height=16] within a text block.
+This line has an inline image image:../images/frisbee.png[] within a text block.
 
 == Remote Images
 


### PR DESCRIPTION
Resolves #475 