### PR TITLE
Fix image border when using new Confluence editor

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_image.html.slim
@@ -1,5 +1,7 @@
 = html_a_tag_if (attr? :link)
   ac:image ac:height=(attr :height) ac:width=(attr :width) ac:title=(title if title?) ac:alt=(title if title?) ac:border=(attr :border if attr :border) ac:custom-width=("true" if attr(:width) || attr(:height))
+    - if attr :border
+      ac:adf-mark key="border" size="2" color="#091e4224"
     - if uriish? attr :target
       ri:url ri:value=(attr :target)
     - else

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/inline_image.html.slim
@@ -1,6 +1,8 @@
 = html_a_tag_if (attr? :link)
   span
     ac:image ac:height=(attr :height) ac:width=(attr :width) ac:alt=(attr :alt if attr :alt) ac:border=(attr :border if attr :border) ac:custom-width=("true" if attr(:width) || attr(:height))
+      - if attr :border
+        ac:adf-mark key="border" size="2" color="#091e4224"
       - if uriish? target
         ri:url ri:value=(target)
       - else

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -798,7 +798,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<ac:image ac:border=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image>";
+        String expectedContent = "<ac:image ac:border=\"true\"><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\"></ac:adf-mark><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 
@@ -1581,7 +1581,7 @@ public class AsciidocConfluencePageTest {
         AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
-        String expectedContent = "<p>Some text <span><ac:image ac:alt=\"sunset\" ac:border=\"true\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span> with inline image</p>";
+        String expectedContent = "<p>Some text <span><ac:image ac:alt=\"sunset\" ac:border=\"true\"><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\"></ac:adf-mark><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></span> with inline image</p>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/06-images.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/06-images.adoc
@@ -86,16 +86,16 @@ Block images can have a border added.
 
 [listing]
 ....
-image::../images/frisbee.png[border]
+image::../images/frisbee.png[border=true]
 ....
 
-image::../images/frisbee.png[border]
+image::../images/frisbee.png[border=true]
 
 So can inline images:
 
 [listing]
 ....
-This line has an inline image image:../images/frisbee.png[width=16, height=16, border].
+This line has an inline image image:../images/frisbee.png[width=16, height=16, border=true].
 ....
 
-This line has an inline image image:../images/frisbee.png[width=16, height=16, border] within a text block.
+This line has an inline image image:../images/frisbee.png[width=16, height=16, border=true] with a border within a text block.


### PR DESCRIPTION
Resolves #479 