### PR TITLE
build: replace spotify dockerfile-maven-plugin with fabric8 docker-maven-plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
         run: |
           echo $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin
-          ./mvnw -pl asciidoc-confluence-publisher-docker dockerfile:push -nsu
+          ./mvnw -pl asciidoc-confluence-publisher-docker docker:push -nsu
 
       - name: prepare cache
         if: always()

--- a/asciidoc-confluence-publisher-docker/pom.xml
+++ b/asciidoc-confluence-publisher-docker/pom.xml
@@ -108,21 +108,27 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.13</version>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>default</id>
+                        <id>build-docker-image</id>
+                        <phase>package</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
-                    <repository>confluencepublisher/confluence-publisher</repository>
-                    <tag>${project.version}</tag>
-                    <googleContainerRegistryEnabled>false</googleContainerRegistryEnabled>
+                    <images>
+                        <image>
+                            <name>confluencepublisher/confluence-publisher:${project.version}</name>
+                            <build>
+                                <dockerFile>${project.basedir}/Dockerfile</dockerFile>
+                                <contextDir>${project.basedir}</contextDir>
+                            </build>
+                        </image>
+                    </images>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Summary

Replaces the abandoned spotify `dockerfile-maven-plugin` with the already declared but unused fabric8 `docker-maven-plugin` (v0.48.1 from pluginManagement).

The spotify plugin fails on Apple Silicon with `UnsatisfiedLinkError` due to missing arm64 native libraries, so the Docker module can't be built locally.

A similar migration was attempted before (c6982cb) but reverted (30a99e2) due to CircleCI build failures. Since the project has moved to GitHub Actions in the meantime, I believe that dependency is no longer relevant.

The project builds successfully with this change and I've structurally compared the resulting Docker image against the published 0.30.0 — looks the same. 🙂

That said, I might be missing something — happy if you double-check and let me know if there are concerns! 😅