### PR TITLE
Add missing [%collapsible] option

### DIFF
--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/12-table-of-contents.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/12-table-of-contents.adoc
@@ -53,7 +53,7 @@ Custom table of contents title using some bold text:
 = Page Title
 :toc: macro
 
-*Table of Contents*
+*My Table of Contents*
 
 toc::[]
 
@@ -67,8 +67,7 @@ Custom table of contents title using a collapsible block title:
 = Page Title
 :toc: macro
 
-.Table of Contents
-[%collapsible]
+.My Table of Contents
 ====
 toc::[]
 ====

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/12-table-of-contents.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/12-table-of-contents.adoc
@@ -53,7 +53,7 @@ Custom table of contents title using some bold text:
 = Page Title
 :toc: macro
 
-*My Table of Contents*
+*Table of Contents*
 
 toc::[]
 
@@ -67,7 +67,7 @@ Custom table of contents title using a collapsible block title:
 = Page Title
 :toc: macro
 
-.My Table of Contents
+.Table of Contents
 [%collapsible]
 ====
 toc::[]

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/12-table-of-contents.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/12-table-of-contents.adoc
@@ -68,6 +68,7 @@ Custom table of contents title using a collapsible block title:
 :toc: macro
 
 .My Table of Contents
+[%collapsible]
 ====
 toc::[]
 ====


### PR DESCRIPTION
The collapsible TOC example is incomplete and does not work without the [%collapsible] option.

Resolves #514 