### PR TITLE
Issue 519 add support for rust language highlighting

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/helpers.rb
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/helpers.rb
@@ -135,8 +135,8 @@ module Slim::Helpers
     supported = ['actionscript3','applescript','bash','c#','cpp','css',
                 'coldfusion','delphi','diff','erl','groovy',
                 'xml','java','jfx','js','matlab','php','perl',
-                'text','powershell','py','ruby','sql','sass',
-                'scala','vb','yml']
+                'text','powershell','py','ruby','rust','sql','sass',
+                'scala','toml','vb','yml']
     supported.include? lang
   end
 
@@ -159,6 +159,7 @@ module Slim::Helpers
         'ps' => 'powershell', 'ps1' => 'powershell',
         'python' => 'py', 'gyp' => 'py',
         'rb' => 'ruby', 'gemspec' => 'ruby', 'podspec' => 'ruby', 'thor' => 'ruby', 'irb' => 'ruby',
+        'rs' => 'rust',
         'vbnet' => 'vb', 'vbscript' => 'vb', 'vbs' => 'vb',
         'yaml' => 'yml'
       }

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/07-listings.adoc
@@ -40,8 +40,8 @@ this is a listing block
 
 Source blocks are converted using the "code" macro. Only languages supported by the Code Block Macro can be used:
 `actionscript3`, `applescript`, `bash`, `c#`, `cpp`, `css`, `coldfusion`, `delphi`, `diff`, `erl`, `groovy`,
-`xml`, `java`, `jfx`, `js`, `php`, `perl`, `text`, `powershell`, `py`, `ruby`, `sql`, `sass`, `scala`,
-`vb`, `yml` (since Confluence 6.7 only)
+`xml`, `java`, `jfx`, `js`, `php`, `perl`, `text`, `powershell`, `py`, `ruby`, `rust`, `sql`, `sass`, `scala`,
+`toml`, `vb`, `yml` (since Confluence 6.7 only)
 
 [listing]
 ....


### PR DESCRIPTION
added `toml` and `rust` as supported languages

Resolves #519 