### PR TITLE
Add support for starting ordered lists at a specified point

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_olist.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_olist.html.slim
@@ -1,7 +1,7 @@
 - if title?
   div class="cp-olist-title"
     em =title
-ol
+ol start=(attr :start if attr :start)
   - items.each do |item|
     li
       =item.text

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -1541,6 +1541,26 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithOrderedListWithStart_returnsConfluencePageHavingCorrectOrderedListMarkup() {
+        // arrange
+        String adocContent =
+                ". L1-1\n" +
+                ". L1-2\n" +
+                "\n" +
+                "Some other text\n" +
+                "[start=3]\n"+
+                ". L1-3";
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ol><li>L1-1</li><li>L1-2</li></ol>\n<p>Some other text</p>\n<ol start=\"3\"><li>L1-3</li></ol>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithOrderedListAndTitle_returnsConfluencePageHavingCorrectOrderedListAndTitleMarkup() {
         // arrange
         String adocContent = ".An ordered list title\n" +


### PR DESCRIPTION
It seems like Confluence Cloud (at least) supports continuing lists now. This seems to have been done in https://jira.atlassian.com/browse/CONFCLOUD-7794. Testing on our instance shows this works as expected. 

I have not currently updated any documentation since there's not an obvious place to put documentation on how to do lists. It seems like you are expected to know that from the general AsciiDoc documentation. This adds support for the `start` attribute on ordered lists - https://docs.asciidoctor.org/asciidoc/latest/lists/ordered/#basic-ordered-list. 

Resolves #121